### PR TITLE
fix: pin urllib3 to v1.x to resolve LibreSSL compatibility warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4>=4.12.0
 argparse
 python-xbrl>=1.1.1
 pandas>=2.0.0
+urllib3<2.0


### PR DESCRIPTION
Adds urllib3<2.0 constraint to requirements.txt to fix the urllib3 v2 compatibility warning with LibreSSL 2.8.3. This ensures stable functionality for EDINET financial data extraction.

Resolves #2

Generated with [Claude Code](https://claude.ai/code)