### PR TITLE
feat: add PDF URL field to response JSON

### DIFF
--- a/lib/xbrl_parser.py
+++ b/lib/xbrl_parser.py
@@ -332,6 +332,7 @@ class XBRLParser:
             "secCode": sec_code,
             "filerName": filer_name,
             "docID": doc_id,
+            "docPdfURL": f"https://disclosure2dl.edinet-fsa.go.jp/searchdocument/pdf/{doc_id}.pdf",
             "periodEnd": format_period_end(period_end),
             "characteristic": self._extract_characteristic(root),
             "stockPrice": self._extract_stock_price(root),


### PR DESCRIPTION
Add "docPdfURL" field to financial data response containing direct link to EDINET PDF documents. This enhances debugging capabilities by providing easy access to source documents.

URL format: https://disclosure2dl.edinet-fsa.go.jp/searchdocument/pdf/{docID}.pdf

Resolves #8

Generated with [Claude Code](https://claude.ai/code)