### PR TITLE
feat: add Yahoo Finance URL to response JSON

### DIFF
--- a/lib/xbrl_parser.py
+++ b/lib/xbrl_parser.py
@@ -333,6 +333,7 @@ class XBRLParser:
             "filerName": filer_name,
             "docID": doc_id,
             "docPdfURL": f"https://disclosure2dl.edinet-fsa.go.jp/searchdocument/pdf/{doc_id}.pdf",
+            "yahooURL": f"https://finance.yahoo.co.jp/quote/{sec_code}.T",
             "periodEnd": format_period_end(period_end),
             "characteristic": self._extract_characteristic(root),
             "stockPrice": self._extract_stock_price(root),


### PR DESCRIPTION
Add yahooURL field to financial data response structure using format:
https://finance.yahoo.co.jp/quote/{secCode}.T

Securities code is already normalized to 4 digits by existing code flow.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)