### PR TITLE
feat: implement calculated financial fields (Issue #21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ This modularization improves code maintainability, reduces duplication, and prov
 - Focus on reliable, verifiable financial data from official sources
 - Extract available metrics: netSales, employees, operatingIncome, equity, netIncome, outstandingShares, eps, cash, bps, debt
 - Calculate derived metrics: operatingIncomeRate, ebitda, ebitdaMargin, ev, evPerEbitda
+- Calculate fallback financial fields: stockPrice (eps × per), marketCapitalization (outstandingShares × stockPrice), pbr (stockPrice ÷ bps)
 - Advanced extraction: Dynamic search algorithms for PER, EPS, outstanding shares, cash, BPS, and debt when standard patterns fail
 
 ## Technical Implementation Guidelines
@@ -109,6 +110,13 @@ This modularization improves code maintainability, reduces duplication, and prov
 - **Cash and Cash Equivalents**: Successfully implemented with period-end prioritization and consolidated data preference
 - **Context Hierarchy**: Established priority order: Consolidated+CurrentYear > CurrentYear > Consolidated > Others
 - **Field Positioning**: New financial metrics should be positioned before retrievedDate field in JSON structure
+
+### Calculated Financial Fields Implementation (2025-06-23)
+- **Issue #21 Resolution**: Implemented null-safe calculations for fields not directly available from EDINET API
+- **Fallback Calculations**: Added stockPrice (eps × per), marketCapitalization (outstandingShares × stockPrice), pbr (stockPrice ÷ bps)
+- **Enterprise Value Correction**: Fixed EV calculation to properly include cash subtraction (marketCapitalization + debt - cash)
+- **Null Safety Strategy**: If any required parameter is null, calculated parameter is also null to maintain data integrity
+- **Calculation Priority**: Prefer direct EDINET extraction over calculated values, use calculations only as fallbacks
 
 ## Future Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The system extracts the following financial metrics from XBRL data:
 | secCode | 4-digit securities code | String |
 | periodEnd | Fiscal period end | String |
 | characteristic | Company characteristics | String |
-| stockPrice | Stock price at fiscal year end | Number |
+| stockPrice | Stock price at fiscal year end (calculated: eps × per if missing) | Number |
 | netSales | Total net sales | Number |
 | employees | Number of employees | Number |
 | operatingIncome | Operating income | Number |
@@ -118,11 +118,11 @@ The system extracts the following financial metrics from XBRL data:
 | depreciation | Depreciation expenses | Number |
 | ebitda | EBITDA | Number |
 | ebitdaMargin | EBITDA margin (%) | Number |
-| marketCapitalization | Market capitalization | Number |
+| marketCapitalization | Market capitalization (calculated: outstandingShares × stockPrice if missing) | Number |
 | per | Price-to-earnings ratio | Number |
-| ev | Enterprise value | Number |
+| ev | Enterprise value (calculated: marketCapitalization + debt - cash) | Number |
 | evPerEbitda | Enterprise value / EBITDA | Number |
-| pbr | Price-to-book ratio | Number |
+| pbr | Price-to-book ratio (calculated: stockPrice ÷ bps if missing) | Number |
 | bps | Book value per share | Number |
 | equity | Total equity/shareholders' equity | Number |
 | debt | Net interest-bearing debt | Number |


### PR DESCRIPTION
Add null-safe calculations for financial fields not directly available from EDINET API:
- stockPrice = eps × per (fallback calculation)
- marketCapitalization = outstandingShares × stockPrice (fallback calculation)
- pbr = stockPrice ÷ bps (fallback calculation)
- ev = marketCapitalization + debt - cash (fixed to include cash subtraction)
- evPerEbitda = ev ÷ ebitda (improved null handling)

All calculations follow null safety requirements and are only used as fallbacks when direct EDINET extraction fails.

Resolves #21

Generated with [Claude Code](https://claude.ai/code)