### PR TITLE
fix: Set stock price and related variables to null when eps is negative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,12 @@ This modularization improves code maintainability, reduces duplication, and prov
 - **Null Safety Strategy**: If any required parameter is null, calculated parameter is also null to maintain data integrity
 - **Calculation Priority**: Prefer direct EDINET extraction over calculated values, use calculations only as fallbacks
 
+### Negative EPS Handling (2025-06-26)
+- **Issue #28 Resolution**: Enhanced null-safety for negative earnings scenarios
+- **Stock Price Logic**: When eps < 0, stockPrice is set to null (negative stock prices are meaningless)
+- **PER Logic**: When eps ≤ 0, PER cannot be calculated and is set to null
+- **Cascade Effect**: All dependent calculations (marketCapitalization, pbr, ev, evPerEbitda) automatically become null when stockPrice is null
+
 ## Future Development Guidelines
 
 ### Maintainability Focus

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The system extracts the following financial metrics from XBRL data:
 | secCode | 4-digit securities code | String |
 | periodEnd | Fiscal period end | String |
 | characteristic | Company characteristics | String |
-| stockPrice | Stock price at fiscal year end (calculated: eps × per if missing) | Number |
+| stockPrice | Stock price at fiscal year end (calculated: eps × per if missing, null if eps < 0) | Number |
 | netSales | Total net sales | Number |
 | employees | Number of employees | Number |
 | operatingIncome | Operating income | Number |

--- a/lib/xbrl_parser.py
+++ b/lib/xbrl_parser.py
@@ -351,12 +351,15 @@ class MetricsCalculator:
                 financial_data['ebitdaMargin'] = (financial_data['ebitda'] / net_sales) * 100
             
             # Calculate missing financial metrics (Issue #21)
-            # stockPrice = eps × per (only if stockPrice is missing)
+            # stockPrice = eps × per (only if stockPrice is missing and eps >= 0)
             if not financial_data.get('stockPrice'):
                 eps = financial_data.get('eps')
                 per = financial_data.get('per')
                 if eps is not None and per is not None:
-                    financial_data['stockPrice'] = eps * per
+                    if eps >= 0:  # Issue #28: Only calculate stock price for non-negative eps
+                        financial_data['stockPrice'] = eps * per
+                    else:
+                        financial_data['stockPrice'] = None  # Set to null for negative eps
                 else:
                     financial_data['stockPrice'] = None
             


### PR DESCRIPTION
Fixes issue #28

When eps (earnings per share) is negative, calculating stockPrice = eps × per results in a negative stock price, which is meaningless in financial analysis.

## Changes

- Modified stock price calculation to check eps >= 0 before computing stockPrice
- When eps < 0, stockPrice is set to null instead of negative value
- PER calculation already correctly handles eps <= 0 by setting to null
- All dependent variables (marketCapitalization, pbr, ev, evPerEbitda) automatically become null due to existing null-safety logic
- Updated documentation in CLAUDE.md and README.md to reflect the change

Generated with [Claude Code](https://claude.ai/code)