### PR TITLE
docs: ドキュメントの修正 - Issue #32, #37

### DIFF
--- a/.ai-rules/web-viewer.md
+++ b/.ai-rules/web-viewer.md
@@ -53,7 +53,7 @@ docs/
 7. **営業利益（百万円）** (operatingIncome)
 8. **営業利益率（%）** (operatingIncomeRate) - 小数点1桁
 9. **EBITDA（百万円）** (ebitda)
-10. **EDITDAマージン（%）** (ebitdaMargin) - 小数点1桁
+10. **EBITDAマージン（%）** (ebitdaMargin) - 小数点1桁
 11. **時価総額（百万円）** (marketCapitalization)
 12. **PER（倍）** (per) - 小数点1桁
 13. **企業価値（百万円）** (ev)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ Consolidates multiple daily JSON files into a single file.
 
 | Field | Description | Type |
 |-------|-------------|------|
+| docID | EDINET document ID | String |
 | secCode | 4-digit securities code | String |
+| filerName | Company name | String |
+| docPdfURL | Securities report PDF URL | String |
+| yahooURL | Yahoo Finance URL | String |
 | periodEnd | Fiscal period end (YYYY年M月期) | String |
 | characteristic | Company characteristics | String |
 | stockPrice | Stock price at fiscal year end | Number |
@@ -99,6 +103,7 @@ Consolidates multiple daily JSON files into a single file.
 | employees | Number of employees | Number |
 | operatingIncome | Operating income | Number |
 | operatingIncomeRate | Operating income rate (%) | Number |
+| depreciation | Depreciation | Number |
 | marketCapitalization | Market capitalization | Number |
 | per | Price-to-earnings ratio | Number |
 | pbr | Price-to-book ratio | Number |


### PR DESCRIPTION
## Summary
- Issue #32: README.mdのExtracted Financial Metricsテーブルを更新
- Issue #37: web-viewer.mdのタイポ修正（EDITDA → EBITDA）

## 変更内容

### README.md
実際のJSONデータ構造に合わせて、Extracted Financial Metricsテーブルに以下の5つのフィールドを追加しました：
- `docID`: EDINET文書ID
- `filerName`: 企業名称
- `docPdfURL`: 有価証券報告書PDFのURL
- `yahooURL`: Yahoo\!ファイナンスのURL
- `depreciation`: 減価償却費

### .ai-rules/web-viewer.md
56行目の「EDITDAマージン」を正しい「EBITDAマージン」に修正しました。

## Test plan
- [x] ドキュメントの変更のみのため、機能への影響なし
- [x] 全てのテストが合格（10 passed）

Fixes #32, #37

🤖 Generated with [Claude Code](https://claude.ai/code)