### PR TITLE
fix: マジックナンバーを定数として定義 (#40)

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,7 @@
+// 定数定義
+const SCROLL_THRESHOLD = 300;  // トップへ戻るボタンの表示閾値（ピクセル）
+const MILLION = 1000000;       // 百万円単位への変換
+
 let allData = [];
 
 // ページ読み込み時の処理
@@ -70,7 +74,7 @@ function formatNumber(value) {
     if (value === null || value === undefined) {
         return '-';
     }
-    const millionValue = Math.round(value / 1000000);
+    const millionValue = Math.round(value / MILLION);
     return millionValue.toLocaleString('ja-JP');
 }
 
@@ -191,7 +195,7 @@ function setupBackToTopButton() {
     
     // テーブルコンテナのスクロールを監視
     tableContainer.addEventListener('scroll', () => {
-        if (tableContainer.scrollTop > 300) {
+        if (tableContainer.scrollTop > SCROLL_THRESHOLD) {
             backToTopButton.classList.add('visible');
         } else {
             backToTopButton.classList.remove('visible');

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,3 +1,9 @@
+:root {
+    --column-sec-code-width: 100px;
+    --column-company-name-width: 200px;
+    --tooltip-width: 300px;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -163,7 +169,7 @@ td {
     padding: 0.5rem;
     border-radius: 4px;
     white-space: normal;
-    width: 300px;
+    width: var(--tooltip-width);
     z-index: 1000;
     box-shadow: 0 4px 8px rgba(0,0,0,0.2);
     font-size: 12px;
@@ -214,15 +220,15 @@ td:nth-child(2) {
 th:nth-child(1),
 td:nth-child(1) {
     left: 0;
-    min-width: 100px;
-    max-width: 100px;
+    min-width: var(--column-sec-code-width);
+    max-width: var(--column-sec-code-width);
 }
 
 th:nth-child(2),
 td:nth-child(2) {
-    left: 100px;
-    min-width: 200px;
-    max-width: 200px;
+    left: var(--column-sec-code-width);
+    min-width: var(--column-company-name-width);
+    max-width: var(--column-company-name-width);
 }
 
 /* 固定列のヘッダー */


### PR DESCRIPTION
## Summary
- script.jsとstyles.cssのマジックナンバーを定数/CSS変数として定義
- コードの可読性と保守性を向上

## Changes
### script.js
- `SCROLL_THRESHOLD = 300`: トップへ戻るボタンの表示閾値
- `MILLION = 1000000`: 百万円単位への変換

### styles.css  
- `--column-sec-code-width: 100px`: 証券コード列の幅
- `--column-company-name-width: 200px`: 企業名列の幅
- `--tooltip-width: 300px`: ツールチップの幅

## Test plan
- [x] ローカルサーバーでWebViewerの動作確認
- [x] トップへ戻るボタンが300px以上スクロールで表示されることを確認
- [x] 財務データが百万円単位で正しく表示されることを確認
- [x] テーブルの固定列幅が正しく適用されることを確認

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/code)