### PR TITLE
fix: Excel形式でのデータエクスポート機能を追加 (#41)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
         <div class="search-container">
             <input type="text" id="search-input" placeholder="証券コードで検索...">
             <button id="search-button">検索</button>
+            <button id="export-button">Excelエクスポート</button>
         </div>
     </header>
     
@@ -49,6 +50,7 @@
     
     <button id="back-to-top" title="トップへ戻る">↑</button>
     
+    <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -66,6 +66,21 @@ h1 {
     background-color: #2980b9;
 }
 
+#export-button {
+    padding: 0.5rem 1rem;
+    background-color: #27ae60;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.3s;
+}
+
+#export-button:hover {
+    background-color: #229954;
+}
+
 main {
     padding: 2rem;
     margin-top: 70px; /* ヘッダーの高さ分のマージン */


### PR DESCRIPTION
## Summary
- Webビューアに表示されている財務データをExcel形式（.xlsx）でエクスポートする機能を追加
- 検索ボックスの右側に「Excelエクスポート」ボタンを配置
- SheetJSライブラリを使用してクライアントサイドで完結する実装

## Changes
- `docs/index.html`: SheetJSライブラリのCDN追加とエクスポートボタンの配置
- `docs/script.js`: エクスポート機能の実装（docPdfURL、yahooURLを企業名称の後に追加）
- `docs/styles.css`: エクスポートボタンのスタイル定義（緑色）

## Features
- 全データ（約4,000件）を一括エクスポート
- 日本語カラム名で出力
- 数値データは百万円単位に変換（売上高、営業利益等）
- カラム幅を内容に応じて自動調整
- ファイル名: `edinet_data_YYYYMMDD.xlsx`（実行日付付き）

## Test plan
- [x] pytestの実行（全10テストが合格）
- [ ] ローカル環境でWebビューアを起動して動作確認
- [ ] エクスポートボタンをクリックしてExcelファイルがダウンロードされることを確認
- [ ] ダウンロードしたExcelファイルを開いて内容を確認
- [ ] docPdfURLとyahooURLが企業名称の後に正しく配置されていることを確認

Closes #41

🤖 Generated with [Claude Code](https://claude.ai/code)