### PR TITLE
Issue #57: Document --sec-codes option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Extracts financial data for a specific date.
 **Optional Parameters:**
 - `--verbose, -v`: Enable detailed logging
 - `--max-retries`: Maximum retry attempts (default: 3)
+- `--sec-codes`: Comma-separated list of security codes to filter (e.g., 7203,9984)
 
 **Output:** Creates `{outputdir}/{YYYY-MM-DD}.json`
 


### PR DESCRIPTION
Add missing documentation for the --sec-codes parameter in the fetch_edinet_financial_documents.py command reference section.

This addresses issue #57 by documenting the existing --sec-codes functionality that allows filtering by security codes.

Generated with [Claude Code](https://claude.ai/code)