### PR TITLE
fix: remove lib/ from .gitignore to enable proper tracking of shared libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
Fixes #67

The lib/ entry was preventing proper git tracking of shared library files like edinet_common.py and xbrl_parser.py. These files are part of the project's source code and should be tracked.

Generated with [Claude Code](https://claude.ai/code)