### PR TITLE
feat: add issuedDate field to JSON output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,3 +133,19 @@ python bin/consolidate_documents.py --inputdir data/jsons --output data/edinet.j
   - BusinessResultsOfGroup = 連結データの最も確実な指標
   - ReportingCompany = 個別データの指標
   - 優先度スコアリングによる柔軟な判定が有効
+
+### issuedDateフィールドの追加（2025年7月）
+- **概要**: 有価証券報告書の提出日をJSONに記録
+- **フィールド仕様**:
+  - フィールド名: `issuedDate`
+  - データ型: 文字列
+  - フォーマット: `YYYY-MM-DD`（ISO 8601形式）
+  - データソース: `--date`パラメータ（コマンドライン引数）
+  - JSON内位置: `cash`の後、`retrievedDate`の前
+- **実装詳細**:
+  - `XBRLParser.parse_financial_data()`に`issued_date`パラメータ追加
+  - `XBRLParser._build_financial_data_structure()`に`issued_date`パラメータ追加
+  - `fetch_edinet_financial_documents.py`から`args.date`を渡す
+- **目的**: 
+  - 有価証券報告書の提出日を記録し、時系列分析を可能にする
+  - `retrievedDate`（データ取得日）と区別して実際の報告書提出日を保持

--- a/bin/fetch_edinet_financial_documents.py
+++ b/bin/fetch_edinet_financial_documents.py
@@ -209,7 +209,7 @@ def main():
                         break
                     
                     # Parse financial data
-                    financial_data = xbrl_parser.parse_financial_data(xbrl_content, sec_code, filer_name, doc_id, period_end)
+                    financial_data = xbrl_parser.parse_financial_data(xbrl_content, sec_code, filer_name, doc_id, period_end, args.date)
                     if financial_data:
                         financial_data_list.append(financial_data)
                         logger.info(f"Successfully extracted data for {filer_name}")

--- a/lib/xbrl_parser.py
+++ b/lib/xbrl_parser.py
@@ -715,7 +715,7 @@ class XBRLParser:
         self.calculator = MetricsCalculator()
     
     def parse_financial_data(self, xbrl_content: bytes, sec_code: str, 
-                           filer_name: str, doc_id: str, period_end: str) -> Optional[Dict[str, Any]]:
+                           filer_name: str, doc_id: str, period_end: str, issued_date: str) -> Optional[Dict[str, Any]]:
         """
         Parse XBRL content and extract financial metrics
         
@@ -725,6 +725,7 @@ class XBRLParser:
             filer_name: Company name
             doc_id: Document ID
             period_end: Period end date
+            issued_date: Date when the report was issued (YYYY-MM-DD format)
             
         Returns:
             Dictionary with financial metrics or None if parsing fails
@@ -745,7 +746,7 @@ class XBRLParser:
             
             # Build financial data structure
             financial_data = self._build_financial_data_structure(
-                root, sec_code, filer_name, doc_id, period_end
+                root, sec_code, filer_name, doc_id, period_end, issued_date
             )
             
             # Calculate derived metrics
@@ -759,7 +760,7 @@ class XBRLParser:
             raise XBRLParsingError(f"Error parsing XBRL for {sec_code}: {e}")
     
     def _build_financial_data_structure(self, root: ET.Element, sec_code: str,
-                                      filer_name: str, doc_id: str, period_end: str) -> Dict[str, Any]:
+                                      filer_name: str, doc_id: str, period_end: str, issued_date: str) -> Dict[str, Any]:
         """
         Build the financial data structure from XBRL data
         
@@ -769,6 +770,7 @@ class XBRLParser:
             filer_name: Company name
             doc_id: Document ID
             period_end: Period end date
+            issued_date: Date when the report was issued (YYYY-MM-DD format)
             
         Returns:
             Financial data dictionary
@@ -801,6 +803,7 @@ class XBRLParser:
             "netIncome": self._extract_net_income(root),
             "eps": self._extract_eps(root),
             "cash": self._extract_cash(root),
+            "issuedDate": issued_date,
             "retrievedDate": datetime.now().strftime("%Y-%m-%d")
         }
     


### PR DESCRIPTION
## Summary
- 有価証券報告書の提出日付を`issuedDate`フィールドとしてJSONに追加
- 提出日は`--date`パラメータで指定された日付（YYYY-MM-DD形式）
- `cash`フィールドの後、`retrievedDate`フィールドの前に配置

## Changes
- `lib/xbrl_parser.py`: 
  - `parse_financial_data()`メソッドに`issued_date`パラメータを追加
  - `_build_financial_data_structure()`メソッドに`issued_date`パラメータを追加
  - JSONデータ構造に`"issuedDate": issued_date`を追加
- `bin/fetch_edinet_financial_documents.py`:
  - `parse_financial_data()`呼び出し時に`args.date`を渡すよう変更
- `CLAUDE.md`:
  - `issuedDate`フィールドの仕様を文書化

## Test plan
- [x] 既存のユニットテストが全てパス（23 passed）
- [x] 変更後のコードで新規JSONファイルを生成し、`issuedDate`が正しく追加されることを確認

## Example output
```json
{
  "secCode": "7203",
  "filerName": "トヨタ自動車株式会社",
  ...
  "cash": 197236000000.0,
  "issuedDate": "2025-06-18",
  "retrievedDate": "2025-07-15"
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)