### PR TITLE
docs: document Yahoo Finance integration and data source mapping

### DIFF
--- a/.claude/context/architecture.md
+++ b/.claude/context/architecture.md
@@ -23,10 +23,15 @@ bin/fetch_edinet_financial_documents.py
 │   ├── XBRL namespaces (NAMESPACES)
 │   ├── Logging setup (setup_logging)
 │   └── Utility functions (fetch_document_list, format_date)
-└── lib/xbrl_parser.py
-    ├── XBRLParser class
-    ├── extract_financial_metrics()
-    └── Dynamic search algorithms
+├── lib/xbrl_parser.py
+│   ├── XBRLParser class
+│   ├── extract_financial_metrics()
+│   └── Dynamic search algorithms
+└── lib/data_scraper.py (2025-07 追加)
+    ├── get_financial_data() - メインエントリポイント
+    ├── extract_profile_data() - 企業概要データ取得
+    ├── extract_performance_data() - 業績データ取得
+    └── extract_financial_data() - 財務データ取得
 
 bin/consolidate_documents.py
 └── lib/edinet_common.py
@@ -99,3 +104,63 @@ else:
 - `_dynamic_search_*`: All dynamic search methods check consolidated data availability
 - Priority calculation methods: `_calculate_*_priority()` for consistent scoring
 - Pattern matching maintains backward compatibility for companies with consolidated data
+
+### Yahoo Finance Integration Architecture (2025-07)
+
+#### データ取得フロー
+1. **EDINET API経由でXBRLドキュメントを取得**
+   - 有価証券報告書のメタデータとXBRLファイルをダウンロード
+   - APIレート制限: 1リクエスト/秒を遵守
+
+2. **Yahoo Financeから補完データを取得**
+   - 証券コードをYahooティッカーシンボルに変換（lib/ticker_generator.py）
+   - Playwright（ヘッドレスブラウザ）を使用してデータ取得
+   - 3つのページから情報収集:
+     - `/profile` - 企業概要（特色、従業員数）
+     - `/performance` - 業績データ（売上高、利益等）
+     - `/finance` - 財務データ（EPS、BPS、負債等）
+
+3. **データの統合と計算**
+   - Yahoo Financeデータが利用可能な場合は優先使用
+   - equity と cash は常にXBRLから取得（財務諸表の正式値）
+   - 各種財務指標を計算（PER、PBR、EV/EBITDA等）
+
+#### 技術スタック
+- **Playwright**: ヘッドレスブラウザ自動化フレームワーク
+  - 動的JavaScriptコンテンツの取得に対応
+  - Chromiumブラウザをバックグラウンドで実行
+  - User-Agent設定でアクセス制限を回避
+
+- **データ抽出戦略**:
+  - PRELOADED_STATEからJSONデータを優先的に抽出
+  - フォールバック: HTMLテーブルからのパーシング
+  - ハードコードされたカラムインデックス使用（要改善）
+
+#### データソース分割
+**Yahoo Financeから取得するフィールド**:
+- characteristic（企業特色）
+- stockPrice（株価）
+- netSales（売上高）
+- employees（従業員数）
+- operatingIncome（営業利益）
+- ordinaryIncome（経常利益）※新規追加
+- depreciation（減価償却費）
+- bps（1株当たり純資産）
+- debt（有利子負債）
+- outstandingShares（発行済株式数）
+- netIncome（当期純利益）
+- eps（1株当たり利益）
+
+**EDINETから取得するフィールド**:
+- equity（純資産）
+- cash（現金及び現金同等物）
+
+#### エラーハンドリング
+- Yahoo Finance取得失敗時もXBRL処理を継続
+- 失敗したフィールドはnullを設定
+- XBRLへのフォールバック処理は現在コメントアウト
+
+#### パフォーマンス考慮事項
+- 現在: 企業ごとに新規ブラウザインスタンスを起動
+- 課題: 100社で100回のブラウザ起動（最適化が必要）
+- レート制限: Yahoo Financeへのアクセス制限は未実装

--- a/.claude/context/product-requirements.md
+++ b/.claude/context/product-requirements.md
@@ -11,7 +11,7 @@ EDINET APIを通じて上場企業の有価証券報告書から財務データ�
 - 上場企業情報を調査する財務アナリスト
 
 ### システム構成
-1. **fetch_edinet_financial_documents.py**: 日次データ抽出ツール
+1. **fetch_edinet_financial_documents.py**: 日次データ抽出ツール（EDINET + Yahoo Finance統合）
 2. **consolidate_documents.py**: データ統合ツール
 
 ## 2. 機能要件
@@ -21,6 +21,7 @@ EDINET APIを通じて上場企業の有価証券報告書から財務データ�
 #### 基本機能
 - 指定日のEDINET API経由で有価証券報告書を取得
 - XBRLデータから財務メトリクスを抽出
+- Yahoo Financeから補完データを取得（2025-07追加）
 - JSON形式で出力
 
 #### コマンドライン仕様
@@ -42,6 +43,9 @@ python fetch_edinet_financial_documents.py --date YYYY-MM-DD --outputdir data/js
 | ev | 企業価値 | 52000000000 |
 | equity | 純資産 | 15000000000 |
 | debt | ネット有利子負債 | 2000000000 |
+| ordinaryIncome | 経常利益（2025-07追加） | 1300000000 |
+| ordinaryIncomeRate | 経常利益率（2025-07追加） | 8.67 |
+| characteristic | 企業特色（Yahoo Finance優先） | 【特色】IT企業向けクラウドサービス |
 | （他多数） | | |
 
 ### 2.2 データ統合ツール
@@ -60,12 +64,21 @@ python consolidate_documents.py --inputdir data/jsons/ --output data/edinet.json
 
 ### 3.1 開発環境
 - **言語**: Python 3.x
-- **外部依存**: EDINET API、XBRLパースライブラリ
+- **外部依存**: EDINET API、XBRLパースライブラリ、Playwright（2025-07追加）
 
 ### 3.2 API統合
 - **エンドポイント**: EDINET API
 - **レート制限**: 最大1リクエスト/秒
 - **認証**: APIキー必須
+
+### 3.2.1 Yahoo Finance統合（2025-07追加）
+- **データソース**: finance.yahoo.co.jp
+- **取得方法**: Playwright（ヘッドレスブラウザ）
+- **対象ページ**:
+  - `/profile` - 企業概要（特色、従業員数）
+  - `/performance` - 業績データ（売上高、営業利益、経常利益、当期純利益）
+  - `/finance` - 財務データ（EPS、BPS、負債、減価償却費、発行済株式数）
+- **レート制限**: 未実装（要改善）
 
 ### 3.3 XBRL処理
 

--- a/.claude/examples/development-patterns.md
+++ b/.claude/examples/development-patterns.md
@@ -38,6 +38,43 @@
 3. エラーハンドリングの改善
 4. ログ出力の整合性確認
 
+### Yahoo Finance統合パターン（2025-07追加）
+
+#### Playwrightを使用したWebスクレイピング
+```python
+# ブラウザの起動と設定
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    context = browser.new_context(
+        user_agent='Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36'
+    )
+    page = context.new_page()
+    
+    # ページへのアクセスとデータ取得
+    page.goto(url, wait_until='domcontentloaded', timeout=30000)
+    # PRELOADED_STATEからデータを抽出
+    
+    browser.close()
+```
+
+#### データソースの優先順位
+1. **Yahoo Finance優先**: より新しい市場データと簡潔な企業特色
+2. **XBRL必須データ**: equity（純資産）とcash（現金）は常にXBRLから
+3. **フェイルセーフ**: Yahoo Finance失敗時もXBRL処理を継続
+
+#### エラーハンドリング
+```python
+# Yahoo Financeデータ取得のエラーハンドリング
+try:
+    yahoo_data = get_financial_data(sec_code, formatted_period_end)
+    logger.info(f"Successfully fetched Yahoo Finance data for {sec_code}")
+except Exception as yahoo_error:
+    logger.warning(f"Failed to fetch Yahoo Finance data for {sec_code}: {yahoo_error}")
+    # Continue with XBRL parsing even if Yahoo fails
+```
+
 ## デプロイプロセス
 GitHub Actionsによる自動実行：
 - 毎日午前3時（JST）に自動実行

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,19 @@
 **edinet** - EDINETから上場企業の開示情報を取得・処理するツール
 - EDINET: 日本の企業情報電子開示システム
 - 日次で財務データを自動取得し、構造化されたJSONとして保管
-- Python 3.x + requests/lxml/argparse
+- Python 3.x + requests/lxml/argparse/playwright
 
 ## アーキテクチャ
 
 ```
 edinet/
 ├── bin/                    # 実行可能スクリプト
-├── lib/                    # 共有ライブラリ（edinet_common.py, xbrl_parser.py）
+├── lib/                    # 共有ライブラリ
+│   ├── edinet_common.py   # EDINET API共通処理
+│   ├── xbrl_parser.py     # XBRL解析処理
+│   ├── ticker_generator.py # Yahoo Finance用ティッカー生成
+│   ├── url_generator.py   # Yahoo Finance URL生成
+│   └── data_scraper.py    # Yahoo Financeスクレイピング
 ├── data/jsons/            # 出力データ
 └── .claude/               # Claude Code用の詳細ルール
 ```
@@ -174,3 +179,22 @@ python bin/consolidate_documents.py --inputdir data/jsons --output data/edinet.j
 - **目的**: 
   - 有価証券報告書の提出日を記録し、時系列分析を可能にする
   - `retrievedDate`（データ取得日）と区別して実際の報告書提出日を保持
+
+### Yahoo Finance統合の実装（2025年7月）
+- **概要**: EDINETデータをYahoo Financeのリアルタイム市場データで補完
+- **新規ライブラリ**:
+  - `lib/ticker_generator.py`: 証券コードからYahooティッカーシンボルへの変換
+  - `lib/url_generator.py`: Yahoo Finance URLの生成
+  - `lib/data_scraper.py`: Playwrightを使用したWebスクレイピング
+- **技術的変更**:
+  - Headless Browser (Playwright) を使用したデータ取得
+  - EDINETデータ取得後にYahoo Financeから補完データを取得
+  - 失敗時はEDINETデータのみで処理を継続（フェイルセーフ）
+- **データソース詳細**:
+  - **Yahoo Financeから取得**: characteristic, stockPrice, netSales, employees, operatingIncome, ordinaryIncome（新規）, depreciation, bps, debt, outstandingShares, netIncome, eps
+  - **EDINETから取得**: equity, cash（財務諸表の正式な値が必要なため）
+  - **計算値**: operatingIncomeRate, ordinaryIncomeRate（新規）, ebitda, ebitdaMargin, marketCapitalization, per, ev, evPerEbitda, pbr
+- **注意事項**:
+  - レート制限未実装（Issue #91）
+  - ブラウザインスタンスの最適化が必要（Issue #92）
+  - デバッグprint文の削除が必要（Issue #90）


### PR DESCRIPTION
## Summary
Yahoo Finance統合（PR #88）に関する重要な技術情報をドキュメントに記録しました。

## Changes
- **CLAUDE.md**: Yahoo Finance統合の実装詳細を「最近の重要な修正」セクションに追加
- **.claude/context/architecture.md**: Playwright使用とデータ取得フローの詳細を追加
- **.claude/context/product-requirements.md**: Yahoo Finance統合の要件を追加
- **.claude/examples/development-patterns.md**: Webスクレイピングのベストプラクティスを追加

## Key Documentation Updates
### データソースマッピング
- **Yahoo Financeから取得**: characteristic, stockPrice, netSales, employees, operatingIncome, ordinaryIncome（新規）, depreciation, bps, debt, outstandingShares, netIncome, eps
- **EDINETから取得**: equity, cash（財務諸表の正式値が必要）
- **計算値**: 各種財務指標（PER, PBR, EV/EBITDA等）

### 技術的詳細
- Playwright（ヘッドレスブラウザ）を使用した動的コンテンツの取得
- 3つのYahoo Financeページ（/profile, /performance, /finance）からデータ収集
- フェイルセーフ設計：Yahoo Finance失敗時もEDINET処理を継続

### 既知の課題（Issueとして作成済み）
- レート制限未実装（#91）
- ブラウザインスタンスの最適化が必要（#92）
- デバッグprint文の削除が必要（#90）

## Related
- PR #88: Yahoo Finance統合の実装
- Issues #89-#96: レビューに基づく改善タスク

## Test Plan
ドキュメントのみの変更のため、機能テストは不要です。