### PR TITLE
fix: change webviewer header from '決算期末株価' to '株価'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
                         <th scope="col" class="sortable" data-sort="secCode">証券コード</th>
                         <th scope="col">企業名称</th>
                         <th scope="col">決算期</th>
-                        <th scope="col" aria-label="決算期末株価（円）">決算期末株価<br>(円)</th>
+                        <th scope="col" aria-label="株価（円）">株価<br>(円)</th>
                         <th scope="col" class="sortable" data-sort="netSales" aria-label="売上高（百万円）">売上高<br>(百万円)</th>
                         <th scope="col" class="sortable" data-sort="employees" aria-label="期末従業員数（人）">期末従業員数<br>(人)</th>
                         <th scope="col" class="sortable" data-sort="operatingIncome" aria-label="営業利益（百万円）">営業利益<br>(百万円)</th>

--- a/docs/script.js
+++ b/docs/script.js
@@ -343,7 +343,7 @@ function exportToExcel() {
         '有価証券報告書URL': item.docPdfURL || '',
         'Yahoo!ファイナンスURL': item.yahooURL || '',
         '決算期': item.periodEnd || '',
-        '決算期末株価(円)': item.stockPrice || '',
+        '株価(円)': item.stockPrice || '',
         '売上高(百万円)': item.netSales ? Math.round(item.netSales / MILLION) : '',
         '期末従業員数(人)': item.employees || '',
         '営業利益(百万円)': item.operatingIncome ? Math.round(item.operatingIncome / MILLION) : '',
@@ -370,7 +370,7 @@ function exportToExcel() {
         {wch: 50},  // 有価証券報告書URL
         {wch: 40},  // Yahoo!ファイナンスURL
         {wch: 12},  // 決算期
-        {wch: 15},  // 決算期末株価
+        {wch: 15},  // 株価
         {wch: 15},  // 売上高
         {wch: 15},  // 期末従業員数
         {wch: 15},  // 営業利益


### PR DESCRIPTION
This PR implements the requested change to update the webviewer header from '決算期末株価' to '株価' for improved UI clarity.

## Changes
- Updated HTML table header and aria-label in `docs/index.html`
- Updated Excel export column header in `docs/script.js`
- Updated column width comment in `docs/script.js`

## Impact
- Cosmetic change only - no functionality affected
- Maintains data integrity and accessibility features
- Excel export reflects the new header naming

Fixes #96

Generated with [Claude Code](https://claude.ai/code)