### PR TITLE
feat: add ordinaryIncome and ordinaryIncomeRate columns to Web Viewer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,6 +30,8 @@
                         <th scope="col" class="sortable" data-sort="employees" aria-label="期末従業員数（人）">期末従業員数<br>(人)</th>
                         <th scope="col" class="sortable" data-sort="operatingIncome" aria-label="営業利益（百万円）">営業利益<br>(百万円)</th>
                         <th scope="col" aria-label="営業利益率（パーセント）">営業利益率<br>(%)</th>
+                        <th scope="col" class="sortable" data-sort="ordinaryIncome" aria-label="経常利益（百万円）">経常利益<br>(百万円)</th>
+                        <th scope="col" aria-label="経常利益率（パーセント）">経常利益率<br>(%)</th>
                         <th scope="col" class="sortable" data-sort="ebitda" aria-label="EBITDA（百万円）">EBITDA<br>(百万円)</th>
                         <th scope="col" aria-label="EBITDAマージン（パーセント）">EBITDAマージン<br>(%)</th>
                         <th scope="col" class="sortable" data-sort="marketCapitalization" aria-label="時価総額（百万円）">時価総額<br>(百万円)</th>

--- a/docs/script.js
+++ b/docs/script.js
@@ -58,6 +58,8 @@ function displayData(data) {
             <td class="number-cell">${formatEmployees(item.employees)}</td>
             <td class="number-cell">${formatNumber(item.operatingIncome)}</td>
             <td class="number-cell">${formatPercentage(item.operatingIncomeRate)}</td>
+            <td class="number-cell">${formatNumber(item.ordinaryIncome)}</td>
+            <td class="number-cell">${formatPercentage(item.ordinaryIncomeRate)}</td>
             <td class="number-cell">${formatNumber(item.ebitda)}</td>
             <td class="number-cell">${formatPercentage(item.ebitdaMargin)}</td>
             <td class="number-cell">${formatNumber(item.marketCapitalization)}</td>
@@ -348,6 +350,8 @@ function exportToExcel() {
         '期末従業員数(人)': item.employees || '',
         '営業利益(百万円)': item.operatingIncome ? Math.round(item.operatingIncome / MILLION) : '',
         '営業利益率(%)': item.operatingIncomeRate || '',
+        '経常利益(百万円)': item.ordinaryIncome ? Math.round(item.ordinaryIncome / MILLION) : '',
+        '経常利益率(%)': item.ordinaryIncomeRate || '',
         'EBITDA(百万円)': item.ebitda ? Math.round(item.ebitda / MILLION) : '',
         'EBITDAマージン(%)': item.ebitdaMargin || '',
         '時価総額(百万円)': item.marketCapitalization ? Math.round(item.marketCapitalization / MILLION) : '',
@@ -375,6 +379,8 @@ function exportToExcel() {
         {wch: 15},  // 期末従業員数
         {wch: 15},  // 営業利益
         {wch: 12},  // 営業利益率
+        {wch: 15},  // 経常利益
+        {wch: 12},  // 経常利益率
         {wch: 15},  // EBITDA
         {wch: 15},  // EBITDAマージン
         {wch: 15},  // 時価総額


### PR DESCRIPTION
Adds 経常利益(百万円) and 経常利益率(%) columns to the Web Viewer between operating income rate and EBITDA columns.

Changes:
- Updated HTML table headers with proper aria-labels and sortable attributes
- Added data display in JavaScript using formatNumber() and formatPercentage()
- Included both fields in Excel export with proper formatting and column widths
- Maintains consistent positioning as requested

Resolves #99

Generated with [Claude Code](https://claude.ai/code)