### PR TITLE
docs: update documentation after Yahoo Finance integration

### DIFF
--- a/.claude/context/changelog.md
+++ b/.claude/context/changelog.md
@@ -1,0 +1,111 @@
+# EDINET プロジェクト変更履歴・学習事項
+
+## 概要
+このファイルはEDINETプロジェクトにおける重要な修正履歴、学習事項、技術的な知見を記録します。
+
+## 重要な修正履歴
+
+### 市場時価総額計算の修正
+- **問題**: 自己株式数のみを使用して市場時価総額を計算していた
+- **原因**: EDINETのXBRLパターンの理解不足により、誤ったデータ要素を抽出
+- **解決**: 正しいEDINETパターン `NumberOfIssuedSharesAsOfFiscalYearEndIssuedSharesTotalNumberOfSharesEtc` を最優先に設定
+- **重要な学習**: 
+  - 市場時価総額 = 株価 × 発行済株式総数（自己株式を含む）
+  - EDINETタクソノミーの正確な理解が必要
+  - 存在しないパターン名を使用しないこと
+
+### 非連結財務諸表の条件付き処理
+- **問題**: 連結財務諸表を持たない企業のデータが取得できない
+- **原因**: NonConsolidatedMemberコンテキストのデータを一律除外していた
+- **解決**: 連結財務諸表が存在しない場合のみ非連結データを使用
+- **実装仕様**:
+  - `_has_consolidated_data`メソッドで連結データの有無を判定
+  - 連結データがある場合：従来通り連結データを優先（NonConsolidatedMember除外）
+  - 連結データがない場合：NonConsolidatedMemberデータを使用
+  - 過去データは除外（CurrentYearコンテキストのみ使用）
+- **対象メソッド**: 
+  - `extract_numeric_value_with_context`および全動的検索メソッド
+
+### 連結・個別データの優先順位改善（2025年7月）
+- **問題**: 連結財務諸表を持つ企業でも個別（提出会社）データを取得してしまうバグ
+- **原因**: コンテキスト優先度の判定ロジックが不十分
+- **解決**: 
+  - BusinessResultsOfGroupコンテキストを最優先に設定（+50〜80ポイント）
+  - ReportingCompanyコンテキストにペナルティ付与（-30ポイント）
+  - 連結データ検出ロジックの強化
+- **学習ポイント**:
+  - XBRLのコンテキスト構造を正確に理解することが重要
+  - BusinessResultsOfGroup = 連結データの最も確実な指標
+  - ReportingCompany = 個別データの指標
+  - 優先度スコアリングによる柔軟な判定が有効
+
+### issuedDateフィールドの追加（2025年7月）
+- **概要**: 有価証券報告書の提出日をJSONに記録
+- **フィールド仕様**:
+  - フィールド名: `issuedDate`
+  - データ型: 文字列
+  - フォーマット: `YYYY-MM-DD`（ISO 8601形式）
+  - データソース: `--date`パラメータ（コマンドライン引数）
+  - JSON内位置: `cash`の後、`retrievedDate`の前
+- **実装詳細**:
+  - `XBRLParser.parse_financial_data()`に`issued_date`パラメータ追加
+  - `XBRLParser._build_financial_data_structure()`に`issued_date`パラメータ追加
+  - `fetch_edinet_financial_documents.py`から`args.date`を渡す
+- **目的**: 
+  - 有価証券報告書の提出日を記録し、時系列分析を可能にする
+  - `retrievedDate`（データ取得日）と区別して実際の報告書提出日を保持
+
+### Yahoo Finance統合の実装（2025年7月）
+- **概要**: EDINETデータをYahoo Financeのリアルタイム市場データで補完
+- **新規ライブラリ**:
+  - `lib/ticker_generator.py`: 証券コードからYahooティッカーシンボルへの変換
+  - `lib/url_generator.py`: Yahoo Finance URLの生成
+  - `lib/data_scraper.py`: Playwrightを使用したWebスクレイピング
+- **技術的変更**:
+  - Headless Browser (Playwright) を使用したデータ取得
+  - EDINETデータ取得後にYahoo Financeから補完データを取得
+  - 失敗時はEDINETデータのみで処理を継続（フェイルセーフ）
+- **データソース詳細**:
+  - **Yahoo Financeから取得**: characteristic, stockPrice, netSales, employees, operatingIncome, ordinaryIncome（新規）, depreciation, bps, debt, outstandingShares, netIncome, eps
+  - **EDINETから取得**: equity, cash（財務諸表の正式な値が必要なため）
+  - **計算値**: operatingIncomeRate, ordinaryIncomeRate（新規）, ebitda, ebitdaMargin, marketCapitalization, per, ev, evPerEbitda, pbr
+- **注意事項**:
+  - レート制限未実装（Issue #91）
+  - ブラウザインスタンスの最適化が必要（Issue #92）
+  - デバッグprint文の削除が必要（Issue #90）
+
+## 技術的学習事項
+
+### XBRLタクソノミーの理解
+- EDINETのXBRL構造は企業によって異なるため、動的検索が必要
+- コンテキスト（連結/個別、当期/過去）の優先度設定が重要
+- 存在しないタグ名を使用しないよう、実際のXBRL構造を確認すること
+
+### Yahoo Finance統合の知見
+- Playwrightによるヘッドレスブラウザは安定した データ取得を実現
+- finance.yahoo.co.jpの構造は変更される可能性があるため、定期的な確認が必要
+- レート制限の実装が今後の課題
+
+### データ品質管理
+- 財務データの妥当性検証（負の値、異常な値の処理）
+- データソース間での整合性確認
+- 欠損データの適切な処理とログ出力
+
+## 今後の改善予定
+
+### 技術的改善
+1. Yahoo Financeアクセスのレート制限実装
+2. ブラウザインスタンスの最適化
+3. デバッグprint文の削除
+4. エラーハンドリングの強化
+
+### 機能拡張
+1. 更多財務指標の抽出
+2. 時系列データ分析機能
+3. データ品質レポート機能
+4. 自動化スケジュール機能
+
+## 関連ドキュメント
+- `.claude/context/product-requirements.md` - プロダクト要件詳細
+- `.claude/context/architecture.md` - アーキテクチャ設計
+- `.claude/instructions/debugging-guide.md` - デバッグ手法

--- a/.claude/context/product-requirements.md
+++ b/.claude/context/product-requirements.md
@@ -45,6 +45,7 @@ python fetch_edinet_financial_documents.py --date YYYY-MM-DD --outputdir data/js
 | debt | ネット有利子負債 | 2000000000 |
 | ordinaryIncome | 経常利益（2025-07追加） | 1300000000 |
 | ordinaryIncomeRate | 経常利益率（2025-07追加） | 8.67 |
+| issuedDate | 有価証券報告書提出日（2025-07追加） | 2024-09-30 |
 | characteristic | 企業特色（Yahoo Finance優先） | 【特色】IT企業向けクラウドサービス |
 | （他多数） | | |
 

--- a/.claude/instructions/web-viewer-guide.md
+++ b/.claude/instructions/web-viewer-guide.md
@@ -41,27 +41,29 @@ docs/
 - 仮想スクロールは実装せず、ブラウザのネイティブ性能に依存
 - テーブルコンテナ内でのスクロールで対応
 
-## 表示項目（2025年6月29日更新）
+## 表示項目（2025年8月1日更新）
 
-### カラム定義（全18列）
+### カラム定義（全20列）
 1. **証券コード** (secCode) - 固定列、幅100px
 2. **企業名称** (filerName) - 固定列、幅200px
 3. **決算期** (periodEnd)
-4. **決算期末株価（円）** (stockPrice) - 整数表示
+4. **株価（円）** (stockPrice) - 整数表示
 5. **売上高（百万円）** (netSales)
 6. **期末従業員数（人）** (employees) - 千単位区切り
 7. **営業利益（百万円）** (operatingIncome)
 8. **営業利益率（%）** (operatingIncomeRate) - 小数点1桁
-9. **EBITDA（百万円）** (ebitda)
-10. **EBITDAマージン（%）** (ebitdaMargin) - 小数点1桁
-11. **時価総額（百万円）** (marketCapitalization)
-12. **PER（倍）** (per) - 小数点1桁
-13. **企業価値（百万円）** (ev)
-14. **EV/EBITDA（倍）** (evPerEbitda) - 小数点1桁
-15. **PBR（倍）** (pbr) - 小数点1桁
-16. **純資産合計（百万円）** (equity)
-17. **ネット有利子負債（百万円）** (debt)
-18. **最終更新日** (retrievedDate)
+9. **経常利益（百万円）** (ordinaryIncome)
+10. **経常利益率（%）** (ordinaryIncomeRate) - 小数点1桁
+11. **EBITDA（百万円）** (ebitda)
+12. **EBITDAマージン（%）** (ebitdaMargin) - 小数点1桁
+13. **時価総額（百万円）** (marketCapitalization)
+14. **PER（倍）** (per) - 小数点1桁
+15. **企業価値（百万円）** (ev)
+16. **EV/EBITDA（倍）** (evPerEbitda) - 小数点1桁
+17. **PBR（倍）** (pbr) - 小数点1桁
+18. **純資産合計（百万円）** (equity)
+19. **ネット有利子負債（百万円）** (debt)
+20. **最終更新日** (retrievedDate)
 
 ### 固定列の実装（2025年6月29日追加）
 証券コードと企業名称の2列を固定し、残りは横スクロール可能：
@@ -83,10 +85,6 @@ targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
 targetRow.classList.add('highlight');
 ```
 
-### 事業内容のツールチップ
-- CSS擬似要素（`::after`）で実装
-- `data-full-text`属性に全文を格納
-- ホバー時に`content: attr(data-full-text)`で表示
 
 ### トップへ戻るボタン
 - テーブルコンテナのスクロールを監視
@@ -131,6 +129,10 @@ python3 -m http.server 8080
 4. 公開URL: https://[username].github.io/edinet/
 
 ## 更新履歴
+
+### 2025年8月1日
+- 表示カラムを20列に拡張（ordinaryIncome, ordinaryIncomeRateを追加）
+- 「決算期末株価」を「株価」に修正（実装済み）
 
 ### 2025年6月29日
 - タイトルを「上場企業有価証券報告書 from EDINET」に変更

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,7 @@ edinet/
 - `product-requirements.md` - プロダクト要件
 - `architecture.md` - アーキテクチャ設計
 - `xbrl-taxonomy-notes.md` - XBRL構造の理解と学習事項
+- `changelog.md` - 変更履歴・学習事項
 
 ### instructions/ - 開発指示
 - `coding-standards.md` - コーディング規約
@@ -128,73 +129,12 @@ python bin/consolidate_documents.py --inputdir data/jsons --output data/edinet.j
 
 新機能追加やバグ修正の際は、必ず`.claude/`配下の関連ドキュメントを参照してください。
 
-## 最近の重要な修正
+## 最近の重要な更新
 
-### 市場時価総額計算の修正
-- **問題**: 自己株式数のみを使用して市場時価総額を計算していた
-- **原因**: EDINETのXBRLパターンの理解不足により、誤ったデータ要素を抽出
-- **解決**: 正しいEDINETパターン `NumberOfIssuedSharesAsOfFiscalYearEndIssuedSharesTotalNumberOfSharesEtc` を最優先に設定
-- **重要な学習**: 
-  - 市場時価総額 = 株価 × 発行済株式総数（自己株式を含む）
-  - EDINETタクソノミーの正確な理解が必要
-  - 存在しないパターン名を使用しないこと
+### Yahoo Finance統合の完了（2025年7月）
+Yahoo Financeデータとの統合により、新たに以下のフィールドが追加されました：
+- **ordinaryIncome**: 経常利益
+- **ordinaryIncomeRate**: 経常利益率
+- **issuedDate**: 有価証券報告書の提出日
 
-### 非連結財務諸表の条件付き処理
-- **問題**: 連結財務諸表を持たない企業のデータが取得できない
-- **原因**: NonConsolidatedMemberコンテキストのデータを一律除外していた
-- **解決**: 連結財務諸表が存在しない場合のみ非連結データを使用
-- **実装仕様**:
-  - `_has_consolidated_data`メソッドで連結データの有無を判定
-  - 連結データがある場合：従来通り連結データを優先（NonConsolidatedMember除外）
-  - 連結データがない場合：NonConsolidatedMemberデータを使用
-  - 過去データは除外（CurrentYearコンテキストのみ使用）
-- **対象メソッド**: 
-  - `extract_numeric_value_with_context`および全動的検索メソッド
-
-### 連結・個別データの優先順位改善（2025年7月）
-- **問題**: 連結財務諸表を持つ企業でも個別（提出会社）データを取得してしまうバグ
-- **原因**: コンテキスト優先度の判定ロジックが不十分
-- **解決**: 
-  - BusinessResultsOfGroupコンテキストを最優先に設定（+50〜80ポイント）
-  - ReportingCompanyコンテキストにペナルティ付与（-30ポイント）
-  - 連結データ検出ロジックの強化
-- **学習ポイント**:
-  - XBRLのコンテキスト構造を正確に理解することが重要
-  - BusinessResultsOfGroup = 連結データの最も確実な指標
-  - ReportingCompany = 個別データの指標
-  - 優先度スコアリングによる柔軟な判定が有効
-
-### issuedDateフィールドの追加（2025年7月）
-- **概要**: 有価証券報告書の提出日をJSONに記録
-- **フィールド仕様**:
-  - フィールド名: `issuedDate`
-  - データ型: 文字列
-  - フォーマット: `YYYY-MM-DD`（ISO 8601形式）
-  - データソース: `--date`パラメータ（コマンドライン引数）
-  - JSON内位置: `cash`の後、`retrievedDate`の前
-- **実装詳細**:
-  - `XBRLParser.parse_financial_data()`に`issued_date`パラメータ追加
-  - `XBRLParser._build_financial_data_structure()`に`issued_date`パラメータ追加
-  - `fetch_edinet_financial_documents.py`から`args.date`を渡す
-- **目的**: 
-  - 有価証券報告書の提出日を記録し、時系列分析を可能にする
-  - `retrievedDate`（データ取得日）と区別して実際の報告書提出日を保持
-
-### Yahoo Finance統合の実装（2025年7月）
-- **概要**: EDINETデータをYahoo Financeのリアルタイム市場データで補完
-- **新規ライブラリ**:
-  - `lib/ticker_generator.py`: 証券コードからYahooティッカーシンボルへの変換
-  - `lib/url_generator.py`: Yahoo Finance URLの生成
-  - `lib/data_scraper.py`: Playwrightを使用したWebスクレイピング
-- **技術的変更**:
-  - Headless Browser (Playwright) を使用したデータ取得
-  - EDINETデータ取得後にYahoo Financeから補完データを取得
-  - 失敗時はEDINETデータのみで処理を継続（フェイルセーフ）
-- **データソース詳細**:
-  - **Yahoo Financeから取得**: characteristic, stockPrice, netSales, employees, operatingIncome, ordinaryIncome（新規）, depreciation, bps, debt, outstandingShares, netIncome, eps
-  - **EDINETから取得**: equity, cash（財務諸表の正式な値が必要なため）
-  - **計算値**: operatingIncomeRate, ordinaryIncomeRate（新規）, ebitda, ebitdaMargin, marketCapitalization, per, ev, evPerEbitda, pbr
-- **注意事項**:
-  - レート制限未実装（Issue #91）
-  - ブラウザインスタンスの最適化が必要（Issue #92）
-  - デバッグprint文の削除が必要（Issue #90）
+詳細な変更履歴と技術的な学習事項は `.claude/context/changelog.md` を参照してください。

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This system extracts financial information from XBRL data and compiles it into J
 
 **Key Features:**
 - Automated daily data extraction from EDINET API
-- Extraction of 22 financial metrics from XBRL documents
+- Extraction of 25 financial metrics from XBRL documents
 - Data consolidation across multiple dates
 - Robust error handling and retry mechanisms
 - Clean JSON output format
@@ -104,6 +104,8 @@ Consolidates multiple daily JSON files into a single file.
 | employees | Number of employees | Number |
 | operatingIncome | Operating income | Number |
 | operatingIncomeRate | Operating income rate (%) | Number |
+| ordinaryIncome | Ordinary income | Number |
+| ordinaryIncomeRate | Ordinary income rate (%) | Number |
 | depreciation | Depreciation | Number |
 | marketCapitalization | Market capitalization | Number |
 | per | Price-to-earnings ratio | Number |
@@ -115,6 +117,7 @@ Consolidates multiple daily JSON files into a single file.
 | netIncome | Net income | Number |
 | eps | Earnings per share | Number |
 | cash | Cash and cash equivalents | Number |
+| issuedDate | Securities report submission date | String |
 | ebitda | EBITDA | Number |
 | ebitdaMargin | EBITDA margin (%) | Number |
 | ev | Enterprise value | Number |


### PR DESCRIPTION
This PR updates project documentation following the Yahoo Finance integration completion, addressing Issue #101.

## Changes
- Create `.claude/context/changelog.md` with historical content (70 lines)
- Reduce `CLAUDE.md` size from 201 to 141 lines by moving detailed sections
- Add ordinaryIncome, ordinaryIncomeRate, issuedDate to README.md metrics table
- Update metrics count from 22 to 25 fields
- Add issuedDate field to product-requirements.md
- Update web-viewer-guide.md: fix display items, add new fields, update column count to 20
- Eliminate documentation duplication by centralizing historical information

Closes #101

Generated with [Claude Code](https://claude.ai/code)