### PR TITLE
Add test coverage for Yahoo Finance functionality

### DIFF
--- a/tests/test_data_scraper.py
+++ b/tests/test_data_scraper.py
@@ -1,0 +1,359 @@
+import unittest
+from unittest.mock import Mock, patch, MagicMock, call
+import os
+import sys
+import json
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lib.data_scraper import (
+    extract_preloaded_state,
+    parse_numeric_value,
+    convert_million_to_yen,
+    convert_thousand_to_shares,
+    extract_profile_data,
+    extract_performance_data,
+    extract_financial_data,
+    get_financial_data
+)
+
+
+class TestDataScraperUtilities(unittest.TestCase):
+    """Test utility functions in data_scraper module"""
+    
+    def test_parse_numeric_value(self):
+        """Test parse_numeric_value function"""
+        test_cases = [
+            ("1,234,567円", "1234567"),
+            ("100人", "100"),
+            ("5,000株", "5000"),
+            ("123", "123"),
+            ("  456  ", "456"),
+            (789, "789"),
+        ]
+        
+        for input_val, expected in test_cases:
+            with self.subTest(input=input_val):
+                result = parse_numeric_value(input_val)
+                self.assertEqual(result, expected)
+    
+    def test_convert_million_to_yen(self):
+        """Test convert_million_to_yen function"""
+        test_cases = [
+            ("51121", 51121000000),
+            ("-1000", -1000000000),
+            ("0", 0),
+            ("---", None),
+            ("N/A", None),
+            ("", None),
+            ("abc", None),
+        ]
+        
+        for input_val, expected in test_cases:
+            with self.subTest(input=input_val):
+                result = convert_million_to_yen(input_val)
+                self.assertEqual(result, expected)
+    
+    def test_convert_thousand_to_shares(self):
+        """Test convert_thousand_to_shares function"""
+        test_cases = [
+            ("58162", 58162000),
+            ("1000", 1000000),
+            ("0", 0),
+            ("---", None),
+            ("N/A", None),
+            ("", None),
+            ("xyz", None),
+        ]
+        
+        for input_val, expected in test_cases:
+            with self.subTest(input=input_val):
+                result = convert_thousand_to_shares(input_val)
+                self.assertEqual(result, expected)
+
+
+class TestDataScraperExtraction(unittest.TestCase):
+    """Test data extraction functions"""
+    
+    def setUp(self):
+        """Set up mock page object"""
+        self.mock_page = Mock()
+        
+    def test_extract_preloaded_state_from_window(self):
+        """Test extracting PRELOADED_STATE from window object"""
+        # Mock successful extraction from window
+        mock_state = {"test": "data"}
+        self.mock_page.evaluate.return_value = mock_state
+        self.mock_page.content.return_value = "<html></html>"
+        
+        result = extract_preloaded_state(self.mock_page)
+        self.assertEqual(result, mock_state)
+        self.mock_page.evaluate.assert_called_once()
+    
+    def test_extract_preloaded_state_fallback_regex(self):
+        """Test extracting PRELOADED_STATE using regex fallback"""
+        # Mock failed window extraction
+        self.mock_page.evaluate.side_effect = Exception("Failed")
+        
+        # Mock HTML content with PRELOADED_STATE
+        html_content = """
+        <script>
+        window.__PRELOADED_STATE__ = {"fallback": "data", "test": 123};
+        window.nextFunction();
+        </script>
+        """
+        self.mock_page.content.return_value = html_content
+        
+        result = extract_preloaded_state(self.mock_page)
+        self.assertEqual(result, {"fallback": "data", "test": 123})
+    
+    def test_extract_preloaded_state_no_data(self):
+        """Test when no PRELOADED_STATE is found"""
+        self.mock_page.evaluate.return_value = None
+        self.mock_page.content.return_value = "<html>No state here</html>"
+        
+        result = extract_preloaded_state(self.mock_page)
+        self.assertEqual(result, {})
+    
+    def test_extract_profile_data(self):
+        """Test extracting profile data from page"""
+        financial_data = {}
+        
+        # Mock PRELOADED_STATE with profile data
+        mock_state = {
+            "mainStocksPriceBoard": {
+                "priceBoard": {
+                    "price": "1,234.5"
+                }
+            },
+            "mainStocksProfile": {
+                "items": [
+                    {
+                        "head": "特色",
+                        "details": [{"text": "自動車メーカー大手"}]
+                    },
+                    {
+                        "head": "従業員数（連結）",
+                        "details": [{"text": "366,283人（23.3）"}]
+                    }
+                ]
+            }
+        }
+        
+        with patch('lib.data_scraper.extract_preloaded_state', return_value=mock_state):
+            extract_profile_data(self.mock_page, financial_data)
+        
+        self.assertEqual(financial_data['stockPrice'], 1234.5)
+        self.assertEqual(financial_data['characteristic'], "自動車メーカー大手")
+        self.assertEqual(financial_data['employees'], 366283)
+    
+    def test_extract_performance_data(self):
+        """Test extracting performance data from page"""
+        financial_data = {}
+        period_end = "2023年3月期"
+        
+        # Mock PRELOADED_STATE with performance data
+        mock_state = {
+            "mainStocksPerformance": {
+                "items": [
+                    {
+                        "period": "2023年3月期",
+                        "sales": "37154",
+                        "operatingIncome": "2725",
+                        "ordinaryIncome": "3932",
+                        "netIncome": "2451"
+                    }
+                ]
+            }
+        }
+        
+        # Mock page selectors for fallback
+        self.mock_page.query_selector_all.return_value = []
+        
+        with patch('lib.data_scraper.extract_preloaded_state', return_value=mock_state):
+            extract_performance_data(self.mock_page, period_end, financial_data)
+        
+        self.assertEqual(financial_data['netSales'], 37154000000)
+        self.assertEqual(financial_data['operatingIncome'], 2725000000)
+        self.assertEqual(financial_data['ordinaryIncome'], 3932000000)
+        self.assertEqual(financial_data['netIncome'], 2451000000)
+    
+    def test_extract_financial_data(self):
+        """Test extracting financial data from page"""
+        financial_data = {}
+        period_end = "2023年3月期"
+        
+        # Mock table structure
+        mock_table = Mock()
+        mock_rows = []
+        
+        # Create mock row with financial data
+        mock_row = Mock()
+        mock_cells = []
+        
+        # Mock cells with text content
+        cell_data = [
+            "2023年3月期",  # Period
+            "123.45",       # EPS
+            "2345.67",      # BPS
+            "---",          # Empty
+            "---",          # Empty
+            "---",          # Empty
+            "---",          # Empty
+            "---",          # Empty
+            "15000",        # Debt
+            "3500",         # Depreciation
+            "432100"        # Outstanding shares
+        ]
+        
+        for data in cell_data:
+            cell = Mock()
+            cell.text_content.return_value = data
+            mock_cells.append(cell)
+        
+        mock_row.query_selector_all.return_value = mock_cells
+        mock_rows.append(mock_row)
+        
+        mock_table.query_selector_all.return_value = mock_rows
+        self.mock_page.query_selector_all.return_value = [mock_table]
+        
+        extract_financial_data(self.mock_page, period_end, financial_data)
+        
+        self.assertEqual(financial_data['eps'], 123.45)
+        self.assertEqual(financial_data['bps'], 2345.67)
+        self.assertEqual(financial_data['debt'], 15000000000)
+        self.assertEqual(financial_data['depreciation'], 3500000000)
+        self.assertEqual(financial_data['outstandingShares'], 432100000)
+
+
+class TestGetFinancialData(unittest.TestCase):
+    """Test the main get_financial_data function"""
+    
+    @patch('lib.ticker_generator.get_ticker_from_security_code')
+    @patch('lib.url_generator.generate_yahoo_finance_urls')
+    @patch('lib.data_scraper.sync_playwright')
+    def test_get_financial_data_success(self, mock_playwright, mock_generate_urls, mock_get_ticker):
+        """Test successful financial data retrieval"""
+        # Setup mocks
+        mock_get_ticker.return_value = "7203.T"
+        mock_generate_urls.return_value = {
+            'profile': 'https://finance.yahoo.co.jp/quote/7203.T/profile',
+            'performance': 'https://finance.yahoo.co.jp/quote/7203.T/performance?styl=performance',
+            'financials': 'https://finance.yahoo.co.jp/quote/7203.T/performance?styl=financials'
+        }
+        
+        # Mock Playwright context
+        mock_page = Mock()
+        mock_context = Mock()
+        mock_browser = Mock()
+        mock_chromium = Mock()
+        mock_p = Mock()
+        
+        mock_playwright.return_value.__enter__.return_value = mock_p
+        mock_p.chromium.launch.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+        
+        # Mock page navigation
+        mock_page.goto.return_value = None
+        
+        # Mock extraction functions
+        with patch('lib.data_scraper.extract_profile_data') as mock_extract_profile:
+            with patch('lib.data_scraper.extract_performance_data') as mock_extract_performance:
+                with patch('lib.data_scraper.extract_financial_data') as mock_extract_financial:
+                    
+                    # Call the function
+                    result = get_financial_data("7203", "2023年3月期")
+                    
+                    # Verify mocks were called
+                    mock_get_ticker.assert_called_once_with("7203")
+                    mock_generate_urls.assert_called_once_with("7203.T")
+                    
+                    # Verify page navigations
+                    self.assertEqual(mock_page.goto.call_count, 3)
+                    
+                    # Verify extraction functions were called
+                    mock_extract_profile.assert_called_once()
+                    mock_extract_performance.assert_called_once()
+                    mock_extract_financial.assert_called_once()
+                    
+                    # Verify browser was closed
+                    mock_browser.close.assert_called_once()
+                    
+                    # Check that all expected fields are in result
+                    expected_fields = [
+                        'stockPrice', 'characteristic', 'employees', 'netSales',
+                        'operatingIncome', 'ordinaryIncome', 'netIncome', 'eps', 'bps',
+                        'depreciation', 'outstandingShares', 'debt'
+                    ]
+                    for field in expected_fields:
+                        self.assertIn(field, result)
+    
+    @patch('lib.ticker_generator.get_ticker_from_security_code')
+    @patch('lib.url_generator.generate_yahoo_finance_urls')
+    @patch('lib.data_scraper.sync_playwright')
+    def test_get_financial_data_with_error(self, mock_playwright, mock_generate_urls, mock_get_ticker):
+        """Test error handling in get_financial_data"""
+        # Setup mocks
+        mock_get_ticker.return_value = "7203.T"
+        mock_generate_urls.return_value = {
+            'profile': 'https://finance.yahoo.co.jp/quote/7203.T/profile',
+            'performance': 'https://finance.yahoo.co.jp/quote/7203.T/performance',
+            'financials': 'https://finance.yahoo.co.jp/quote/7203.T/financials'
+        }
+        
+        # Mock Playwright to raise an error
+        mock_playwright.side_effect = Exception("Network error")
+        
+        # Call should raise the exception
+        with self.assertRaises(Exception) as context:
+            get_financial_data("7203", "2023年3月期")
+        
+        self.assertIn("Network error", str(context.exception))
+    
+    @patch('lib.ticker_generator.get_ticker_from_security_code')
+    @patch('lib.url_generator.generate_yahoo_finance_urls')
+    @patch('lib.data_scraper.sync_playwright')
+    def test_get_financial_data_browser_context(self, mock_playwright, mock_generate_urls, mock_get_ticker):
+        """Test that browser context is set up correctly"""
+        # Setup mocks
+        mock_get_ticker.return_value = "7203.T"
+        mock_generate_urls.return_value = {
+            'profile': 'url1',
+            'performance': 'url2',
+            'financials': 'url3'
+        }
+        
+        # Mock Playwright context
+        mock_page = Mock()
+        mock_context = Mock()
+        mock_browser = Mock()
+        mock_chromium = Mock()
+        mock_p = Mock()
+        
+        mock_playwright.return_value.__enter__.return_value = mock_p
+        mock_p.chromium.launch.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+        
+        # Mock extraction functions
+        with patch('lib.data_scraper.extract_profile_data'):
+            with patch('lib.data_scraper.extract_performance_data'):
+                with patch('lib.data_scraper.extract_financial_data'):
+                    
+                    # Call the function
+                    get_financial_data("7203", "2023年3月期")
+                    
+                    # Verify browser was launched in headless mode
+                    mock_p.chromium.launch.assert_called_once_with(headless=True)
+                    
+                    # Verify context was created with user agent
+                    mock_browser.new_context.assert_called_once()
+                    call_args = mock_browser.new_context.call_args
+                    self.assertIn('user_agent', call_args[1])
+                    self.assertIn('Mozilla', call_args[1]['user_agent'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_ticker_generator.py
+++ b/tests/test_ticker_generator.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest.mock import patch, mock_open
+import os
+import sys
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lib.ticker_generator import get_ticker_from_security_code
+
+
+class TestTickerGenerator(unittest.TestCase):
+    
+    def setUp(self):
+        # Sample YAML content for mocking
+        self.mock_yaml_content = """
+stock_exchanges:
+  '7203': 'T'
+  '9984': 'T'
+  '4755': 'T'
+  '2413': 'N'
+  '3382': 'S'
+  '6701': 'F'
+"""
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_get_ticker_with_mapped_exchange(self, mock_yaml_load, mock_file):
+        """Test ticker generation for security codes with mapped exchanges"""
+        # Mock the YAML loading
+        mock_yaml_load.return_value = {
+            'stock_exchanges': {
+                '7203': 'T',
+                '9984': 'T',
+                '4755': 'T',
+                '2413': 'N',
+                '3382': 'S',
+                '6701': 'F'
+            }
+        }
+        
+        # Test various mapped exchanges
+        test_cases = [
+            ('7203', '7203.T'),  # Tokyo Stock Exchange
+            ('9984', '9984.T'),  # Tokyo Stock Exchange
+            ('2413', '2413.N'),  # Nagoya Stock Exchange
+            ('3382', '3382.S'),  # Sapporo Stock Exchange
+            ('6701', '6701.F'),  # Fukuoka Stock Exchange
+        ]
+        
+        for sec_code, expected_ticker in test_cases:
+            with self.subTest(sec_code=sec_code):
+                result = get_ticker_from_security_code(sec_code)
+                self.assertEqual(result, expected_ticker)
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_get_ticker_default_to_tokyo(self, mock_yaml_load, mock_file):
+        """Test ticker generation defaults to Tokyo Stock Exchange (.T) for unmapped codes"""
+        # Mock the YAML loading with limited mappings
+        mock_yaml_load.return_value = {
+            'stock_exchanges': {
+                '7203': 'T',
+                '9984': 'T'
+            }
+        }
+        
+        # Test unmapped security codes
+        unmapped_codes = ['1234', '5678', '9999', '0000']
+        
+        for sec_code in unmapped_codes:
+            with self.subTest(sec_code=sec_code):
+                result = get_ticker_from_security_code(sec_code)
+                self.assertEqual(result, f"{sec_code}.T")
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_empty_mapping_file(self, mock_yaml_load, mock_file):
+        """Test behavior when mapping file has no stock_exchanges section"""
+        # Mock empty or missing stock_exchanges section
+        mock_yaml_load.return_value = {}
+        
+        result = get_ticker_from_security_code('7203')
+        self.assertEqual(result, '7203.T')
+        
+        # Test with empty dict instead of None
+        mock_yaml_load.return_value = {'stock_exchanges': {}}
+        result = get_ticker_from_security_code('7203')
+        self.assertEqual(result, '7203.T')
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_file_path_construction(self, mock_yaml_load, mock_file):
+        """Test that the correct config file path is constructed"""
+        mock_yaml_load.return_value = {'stock_exchanges': {}}
+        
+        # Call the function
+        get_ticker_from_security_code('7203')
+        
+        # Verify the correct file path was used
+        expected_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'lib', '../config/stock_exchange_mapping.yml'
+        )
+        expected_path = os.path.normpath(expected_path)
+        
+        # Check that open was called with the correct path
+        mock_file.assert_called()
+        actual_path = os.path.normpath(mock_file.call_args[0][0])
+        self.assertEqual(actual_path, expected_path)
+
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('yaml.safe_load')
+    def test_various_security_code_formats(self, mock_yaml_load, mock_file):
+        """Test ticker generation with various security code formats"""
+        mock_yaml_load.return_value = {
+            'stock_exchanges': {
+                '123': 'N',
+                '12345': 'S'
+            }
+        }
+        
+        # Test different length security codes
+        test_cases = [
+            ('123', '123.N'),    # 3-digit code
+            ('12345', '12345.S'), # 5-digit code
+            ('1', '1.T'),        # 1-digit code (unmapped)
+            ('123456', '123456.T') # 6-digit code (unmapped)
+        ]
+        
+        for sec_code, expected_ticker in test_cases:
+            with self.subTest(sec_code=sec_code):
+                result = get_ticker_from_security_code(sec_code)
+                self.assertEqual(result, expected_ticker)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_url_generator.py
+++ b/tests/test_url_generator.py
@@ -1,0 +1,139 @@
+import unittest
+import os
+import sys
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lib.url_generator import generate_yahoo_finance_urls
+
+
+class TestURLGenerator(unittest.TestCase):
+    
+    def test_generate_urls_basic(self):
+        """Test basic URL generation for a standard ticker"""
+        ticker = "7203.T"
+        urls = generate_yahoo_finance_urls(ticker)
+        
+        # Check that all expected keys are present
+        expected_keys = ['profile', 'performance', 'financials']
+        self.assertEqual(set(urls.keys()), set(expected_keys))
+        
+        # Check URL structure
+        base_url = "https://finance.yahoo.co.jp/quote/"
+        self.assertEqual(urls['profile'], f"{base_url}7203.T/profile")
+        self.assertEqual(urls['performance'], f"{base_url}7203.T/performance?styl=performance")
+        self.assertEqual(urls['financials'], f"{base_url}7203.T/performance?styl=financials")
+
+    def test_generate_urls_different_exchanges(self):
+        """Test URL generation for tickers from different exchanges"""
+        test_cases = [
+            "7203.T",  # Tokyo
+            "2413.N",  # Nagoya
+            "3382.S",  # Sapporo
+            "6701.F",  # Fukuoka
+        ]
+        
+        base_url = "https://finance.yahoo.co.jp/quote/"
+        
+        for ticker in test_cases:
+            with self.subTest(ticker=ticker):
+                urls = generate_yahoo_finance_urls(ticker)
+                
+                # Verify URLs contain the correct ticker
+                self.assertIn(ticker, urls['profile'])
+                self.assertIn(ticker, urls['performance'])
+                self.assertIn(ticker, urls['financials'])
+                
+                # Verify URL structure
+                self.assertEqual(urls['profile'], f"{base_url}{ticker}/profile")
+                self.assertEqual(urls['performance'], f"{base_url}{ticker}/performance?styl=performance")
+                self.assertEqual(urls['financials'], f"{base_url}{ticker}/performance?styl=financials")
+
+    def test_generate_urls_special_characters(self):
+        """Test URL generation with various ticker formats"""
+        # Test with numbers only, dots, and other variations
+        test_cases = [
+            "1234",      # No exchange suffix
+            "1234.T",    # Standard format
+            "12345.T",   # 5-digit code
+            "123.T",     # 3-digit code
+            "1.T",       # Single digit
+        ]
+        
+        for ticker in test_cases:
+            with self.subTest(ticker=ticker):
+                urls = generate_yahoo_finance_urls(ticker)
+                
+                # Should always return a dictionary with 3 keys
+                self.assertEqual(len(urls), 3)
+                self.assertIn('profile', urls)
+                self.assertIn('performance', urls)
+                self.assertIn('financials', urls)
+                
+                # URLs should contain the ticker as-is
+                for url in urls.values():
+                    self.assertIn(ticker, url)
+
+    def test_url_format_consistency(self):
+        """Test that URLs maintain consistent format"""
+        ticker = "9984.T"
+        urls = generate_yahoo_finance_urls(ticker)
+        
+        # All URLs should start with HTTPS
+        for url in urls.values():
+            self.assertTrue(url.startswith("https://"))
+        
+        # Check for consistent domain
+        for url in urls.values():
+            self.assertIn("finance.yahoo.co.jp", url)
+        
+        # Performance and financials should have query parameters
+        self.assertIn("?styl=performance", urls['performance'])
+        self.assertIn("?styl=financials", urls['financials'])
+        
+        # Profile should not have query parameters
+        self.assertNotIn("?", urls['profile'])
+
+    def test_return_type(self):
+        """Test that the function returns the correct type"""
+        ticker = "7203.T"
+        result = generate_yahoo_finance_urls(ticker)
+        
+        # Should return a dictionary
+        self.assertIsInstance(result, dict)
+        
+        # All values should be strings
+        for key, value in result.items():
+            self.assertIsInstance(key, str)
+            self.assertIsInstance(value, str)
+
+    def test_empty_ticker(self):
+        """Test behavior with empty ticker"""
+        ticker = ""
+        urls = generate_yahoo_finance_urls(ticker)
+        
+        # Should still return valid structure
+        self.assertEqual(len(urls), 3)
+        
+        # URLs should be formed even with empty ticker
+        base_url = "https://finance.yahoo.co.jp/quote/"
+        self.assertEqual(urls['profile'], f"{base_url}/profile")
+        self.assertEqual(urls['performance'], f"{base_url}/performance?styl=performance")
+        self.assertEqual(urls['financials'], f"{base_url}/performance?styl=financials")
+
+    def test_unicode_handling(self):
+        """Test URL generation with unicode characters"""
+        # While tickers are typically alphanumeric, test unicode handling
+        ticker = "1234.東"
+        urls = generate_yahoo_finance_urls(ticker)
+        
+        # Should handle unicode without errors
+        self.assertEqual(len(urls), 3)
+        for url in urls.values():
+            self.assertIsInstance(url, str)
+            self.assertIn(ticker, url)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_yahoo_integration.py
+++ b/tests/test_yahoo_integration.py
@@ -1,0 +1,334 @@
+import unittest
+from unittest.mock import Mock, patch, MagicMock
+import os
+import sys
+from datetime import datetime
+import json
+import zipfile
+import io
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lib.xbrl_parser import XBRLParser
+from lib.data_scraper import get_financial_data
+
+
+class TestYahooFinanceIntegration(unittest.TestCase):
+    """Test integration between Yahoo Finance and XBRL data processing"""
+    
+    def setUp(self):
+        """Set up test fixtures"""
+        self.xbrl_parser = XBRLParser()
+        
+        # Sample Yahoo Finance data
+        self.yahoo_data = {
+            'stockPrice': 2150.5,
+            'characteristic': '世界的な自動車メーカー',
+            'employees': 366283,
+            'netSales': 37154298000000,
+            'operatingIncome': 2725000000000,
+            'ordinaryIncome': 3932000000000,
+            'netIncome': 2451000000000,
+            'eps': 175.23,
+            'bps': 2456.32,
+            'depreciation': 1625000000000,
+            'outstandingShares': 13988000000,
+            'debt': 23759000000000
+        }
+        
+        # Sample XBRL content (minimal valid structure)
+        xbrl_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+        <xbrl xmlns="http://www.xbrl.org/2003/instance"
+              xmlns:jppfs_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2023-03-31/jppfs_cor">
+            <context id="CurrentYearInstant">
+                <entity>
+                    <identifier scheme="http://disclosure.edinet-fsa.go.jp">7203</identifier>
+                </entity>
+                <period>
+                    <instant>2023-03-31</instant>
+                </period>
+            </context>
+            <context id="CurrentYearDuration">
+                <entity>
+                    <identifier scheme="http://disclosure.edinet-fsa.go.jp">7203</identifier>
+                </entity>
+                <period>
+                    <startDate>2022-04-01</startDate>
+                    <endDate>2023-03-31</endDate>
+                </period>
+            </context>
+            <unit id="JPY">
+                <measure>http://www.xbrl.org/2003/iso4217:JPY</measure>
+            </unit>
+            <jppfs_cor:Equity contextRef="CurrentYearInstant" unitRef="JPY" decimals="-6">28552000000000</jppfs_cor:Equity>
+            <jppfs_cor:CashAndCashEquivalents contextRef="CurrentYearInstant" unitRef="JPY" decimals="-6">7560000000000</jppfs_cor:CashAndCashEquivalents>
+        </xbrl>"""
+        
+        # Create a ZIP file containing the XBRL content
+        zip_buffer = io.BytesIO()
+        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+            zip_file.writestr('PublicDoc/document.xbrl', xbrl_xml)
+        self.xbrl_content = zip_buffer.getvalue()
+    
+    def test_xbrl_parser_with_yahoo_data(self):
+        """Test that XBRL parser correctly integrates Yahoo Finance data"""
+        # Parse financial data with Yahoo data
+        result = self.xbrl_parser.parse_financial_data(
+            self.xbrl_content,
+            sec_code="7203",
+            filer_name="トヨタ自動車株式会社",
+            doc_id="S100QXYZ",
+            period_end="2023-03-31",
+            issued_date="2023-06-22",
+            yahoo_data=self.yahoo_data
+        )
+        
+        # Verify that Yahoo Finance data is included
+        self.assertIsNotNone(result)
+        self.assertEqual(result['stockPrice'], 2150.5)
+        self.assertEqual(result['characteristic'], '世界的な自動車メーカー')
+        self.assertEqual(result['employees'], 366283)
+        self.assertEqual(result['netSales'], 37154298000000)
+        self.assertEqual(result['operatingIncome'], 2725000000000)
+        self.assertEqual(result['ordinaryIncome'], 3932000000000)
+        self.assertEqual(result['netIncome'], 2451000000000)
+        self.assertEqual(result['eps'], 175.23)
+        self.assertEqual(result['bps'], 2456.32)
+        
+        # Verify that XBRL data is still extracted
+        self.assertEqual(result['equity'], 28552000000000)
+        self.assertEqual(result['cash'], 7560000000000)
+        
+        # Verify metadata
+        self.assertEqual(result['secCode'], "7203")
+        self.assertEqual(result['filerName'], "トヨタ自動車株式会社")
+        self.assertEqual(result['docID'], "S100QXYZ")
+        self.assertEqual(result['issuedDate'], "2023-06-22")
+    
+    def test_xbrl_parser_without_yahoo_data(self):
+        """Test that XBRL parser works correctly without Yahoo Finance data"""
+        # Parse financial data without Yahoo data
+        result = self.xbrl_parser.parse_financial_data(
+            self.xbrl_content,
+            sec_code="7203",
+            filer_name="トヨタ自動車株式会社",
+            doc_id="S100QXYZ",
+            period_end="2023-03-31",
+            issued_date="2023-06-22",
+            yahoo_data=None
+        )
+        
+        # Verify that result is still valid
+        self.assertIsNotNone(result)
+        
+        # Yahoo-specific fields should be None
+        self.assertIsNone(result['stockPrice'])
+        self.assertIsNone(result['characteristic'])
+        self.assertIsNone(result['employees'])
+        self.assertIsNone(result['netSales'])
+        self.assertIsNone(result['operatingIncome'])
+        self.assertIsNone(result['ordinaryIncome'])
+        
+        # XBRL data should still be present
+        self.assertEqual(result['equity'], 28552000000000)
+        self.assertEqual(result['cash'], 7560000000000)
+    
+    def test_xbrl_parser_with_partial_yahoo_data(self):
+        """Test XBRL parser with partial Yahoo Finance data"""
+        # Create partial Yahoo data
+        partial_yahoo_data = {
+            'stockPrice': 2150.5,
+            'characteristic': '世界的な自動車メーカー',
+            'employees': None,  # Missing data
+            'netSales': 37154298000000,
+            'operatingIncome': None,  # Missing data
+        }
+        
+        result = self.xbrl_parser.parse_financial_data(
+            self.xbrl_content,
+            sec_code="7203",
+            filer_name="トヨタ自動車株式会社",
+            doc_id="S100QXYZ",
+            period_end="2023-03-31",
+            issued_date="2023-06-22",
+            yahoo_data=partial_yahoo_data
+        )
+        
+        # Verify that available Yahoo data is used
+        self.assertEqual(result['stockPrice'], 2150.5)
+        self.assertEqual(result['characteristic'], '世界的な自動車メーカー')
+        self.assertEqual(result['netSales'], 37154298000000)
+        
+        # Missing Yahoo data should be None
+        self.assertIsNone(result['employees'])
+        self.assertIsNone(result['operatingIncome'])
+    
+    def test_calculated_metrics_with_yahoo_data(self):
+        """Test that calculated metrics work correctly with Yahoo Finance data"""
+        result = self.xbrl_parser.parse_financial_data(
+            self.xbrl_content,
+            sec_code="7203",
+            filer_name="トヨタ自動車株式会社",
+            doc_id="S100QXYZ",
+            period_end="2023-03-31",
+            issued_date="2023-06-22",
+            yahoo_data=self.yahoo_data
+        )
+        
+        # Test calculated metrics
+        # Market cap = stock price * outstanding shares
+        expected_market_cap = 2150.5 * 13988000000
+        self.assertEqual(result['marketCapitalization'], expected_market_cap)
+        
+        # PER = stock price / EPS
+        expected_per = 2150.5 / 175.23
+        self.assertAlmostEqual(result['per'], expected_per, places=2)
+        
+        # PBR = stock price / BPS
+        expected_pbr = 2150.5 / 2456.32
+        self.assertAlmostEqual(result['pbr'], expected_pbr, places=2)
+        
+        # Operating income rate = operating income / net sales
+        expected_op_rate = (2725000000000 / 37154298000000) * 100
+        self.assertAlmostEqual(result['operatingIncomeRate'], expected_op_rate, places=2)
+        
+        # Ordinary income rate = ordinary income / net sales
+        expected_ord_rate = (3932000000000 / 37154298000000) * 100
+        self.assertAlmostEqual(result['ordinaryIncomeRate'], expected_ord_rate, places=2)
+    
+    @patch('lib.ticker_generator.get_ticker_from_security_code')
+    @patch('lib.url_generator.generate_yahoo_finance_urls')
+    @patch('lib.data_scraper.sync_playwright')
+    def test_end_to_end_integration(self, mock_playwright, mock_generate_urls, mock_get_ticker):
+        """Test end-to-end integration from Yahoo Finance scraping to XBRL parsing"""
+        # Setup mocks
+        mock_get_ticker.return_value = "7203.T"
+        mock_generate_urls.return_value = {
+            'profile': 'https://finance.yahoo.co.jp/quote/7203.T/profile',
+            'performance': 'https://finance.yahoo.co.jp/quote/7203.T/performance',
+            'financials': 'https://finance.yahoo.co.jp/quote/7203.T/financials'
+        }
+        
+        # Mock Playwright and page interactions
+        mock_page = Mock()
+        mock_context = Mock()
+        mock_browser = Mock()
+        mock_p = Mock()
+        
+        mock_playwright.return_value.__enter__.return_value = mock_p
+        mock_p.chromium.launch.return_value = mock_browser
+        mock_browser.new_context.return_value = mock_context
+        mock_context.new_page.return_value = mock_page
+        
+        # Mock extraction functions to return test data
+        with patch('lib.data_scraper.extract_profile_data') as mock_extract_profile:
+            with patch('lib.data_scraper.extract_performance_data') as mock_extract_performance:
+                with patch('lib.data_scraper.extract_financial_data') as mock_extract_financial:
+                    
+                    # Configure mocks to populate data
+                    def populate_profile(page, data):
+                        data.update({
+                            'stockPrice': 2150.5,
+                            'characteristic': '世界的な自動車メーカー',
+                            'employees': 366283
+                        })
+                    
+                    def populate_performance(page, period, data):
+                        data.update({
+                            'netSales': 37154298000000,
+                            'operatingIncome': 2725000000000,
+                            'ordinaryIncome': 3932000000000,
+                            'netIncome': 2451000000000
+                        })
+                    
+                    def populate_financial(page, period, data):
+                        data.update({
+                            'eps': 175.23,
+                            'bps': 2456.32,
+                            'depreciation': 1625000000000,
+                            'outstandingShares': 13988000000,
+                            'debt': 23759000000000
+                        })
+                    
+                    mock_extract_profile.side_effect = populate_profile
+                    mock_extract_performance.side_effect = populate_performance
+                    mock_extract_financial.side_effect = populate_financial
+                    
+                    # Get Yahoo Finance data
+                    yahoo_result = get_financial_data("7203", "2023年3月期")
+                    
+                    # Parse XBRL with Yahoo data
+                    final_result = self.xbrl_parser.parse_financial_data(
+                        self.xbrl_content,
+                        sec_code="7203",
+                        filer_name="トヨタ自動車株式会社",
+                        doc_id="S100QXYZ",
+                        period_end="2023-03-31",
+                        issued_date="2023-06-22",
+                        yahoo_data=yahoo_result
+                    )
+                    
+                    # Verify complete integration
+                    self.assertIsNotNone(final_result)
+                    self.assertEqual(final_result['stockPrice'], 2150.5)
+                    self.assertEqual(final_result['equity'], 28552000000000)
+                    self.assertIsNotNone(final_result['marketCapitalization'])
+                    self.assertIsNotNone(final_result['per'])
+    
+    def test_yahoo_data_field_mapping(self):
+        """Test that all Yahoo Finance fields are correctly mapped"""
+        # Define expected field mappings
+        yahoo_fields = [
+            'stockPrice', 'characteristic', 'employees', 'netSales',
+            'operatingIncome', 'ordinaryIncome', 'netIncome', 'eps',
+            'bps', 'depreciation', 'outstandingShares', 'debt'
+        ]
+        
+        result = self.xbrl_parser.parse_financial_data(
+            self.xbrl_content,
+            sec_code="7203",
+            filer_name="トヨタ自動車株式会社",
+            doc_id="S100QXYZ",
+            period_end="2023-03-31",
+            issued_date="2023-06-22",
+            yahoo_data=self.yahoo_data
+        )
+        
+        # Verify all Yahoo fields are present in result
+        for field in yahoo_fields:
+            self.assertIn(field, result)
+            self.assertEqual(result[field], self.yahoo_data[field])
+    
+    def test_error_handling_in_integration(self):
+        """Test error handling when Yahoo Finance data has issues"""
+        # Create Yahoo data with invalid values
+        invalid_yahoo_data = {
+            'stockPrice': "invalid",  # Should be numeric
+            'employees': -1,  # Negative value
+            'netSales': None,
+            'eps': 0,  # Zero EPS
+        }
+        
+        # Parser should handle gracefully
+        result = self.xbrl_parser.parse_financial_data(
+            self.xbrl_content,
+            sec_code="7203",
+            filer_name="トヨタ自動車株式会社",
+            doc_id="S100QXYZ",
+            period_end="2023-03-31",
+            issued_date="2023-06-22",
+            yahoo_data=invalid_yahoo_data
+        )
+        
+        # Result should still be valid
+        self.assertIsNotNone(result)
+        
+        # Calculated metrics should handle invalid data gracefully
+        # (PER calculation with zero EPS should result in None or handle appropriately)
+        if 'per' in result:
+            self.assertTrue(result['per'] is None or result['per'] == 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added comprehensive test suite for Yahoo Finance integration features
- Achieved 100% test coverage for ticker_generator.py and url_generator.py
- Added unit tests for data_scraper.py with mocked Playwright dependencies (68% coverage)
- Created integration tests validating the interaction between Yahoo Finance data and XBRL processing

## Test plan
- [x] Run all new tests: `python -m pytest tests/test_ticker_generator.py tests/test_url_generator.py tests/test_data_scraper.py tests/test_yahoo_integration.py -v`
- [x] Verify test coverage meets expectations
- [x] Ensure all 31 tests pass successfully
- [x] Check that Playwright mocks work correctly without requiring actual browser automation

Fixes #89

🤖 Generated with [Claude Code](https://claude.ai/code)