### PR TITLE
feat: restrict web viewer search input to alphanumeric characters only

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <header style="position: fixed !important; top: 0 !important; left: 0 !important; width: 100% !important; z-index: 9999 !important;">
         <h1>上場企業の財務情報</h1>
         <div class="search-container">
-            <input type="text" id="search-input" placeholder="証券コードで検索...">
+            <input type="text" id="search-input" placeholder="証券コードで検索..." pattern="[0-9A-Za-z]*" title="英数字のみ入力可能">
             <button id="search-button">検索</button>
             <button id="export-button">Excelエクスポート</button>
         </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -149,6 +149,43 @@ function setupSearchEvents() {
     // デバウンス付きの検索関数
     const debouncedSearch = debounce(performSearch, DEBOUNCE_DELAY);
     
+    // 入力制限: 英数字のみ許可
+    searchInput.addEventListener('beforeinput', (e) => {
+        // 削除操作は許可
+        if (e.inputType === 'deleteContentBackward' || 
+            e.inputType === 'deleteContentForward' ||
+            e.inputType === 'deleteByCut') {
+            return;
+        }
+        
+        // ペースト操作の場合
+        if (e.inputType === 'insertFromPaste') {
+            // ペースト内容は input イベントで処理
+            return;
+        }
+        
+        // 通常の文字入力の場合
+        if (e.data && !/^[0-9A-Za-z]+$/.test(e.data)) {
+            e.preventDefault();
+        }
+    });
+    
+    // ペースト時の処理と入力値の補正
+    searchInput.addEventListener('input', (e) => {
+        const originalValue = e.target.value;
+        const cleanedValue = originalValue.replace(/[^0-9A-Za-z]/g, '');
+        
+        if (originalValue !== cleanedValue) {
+            e.target.value = cleanedValue;
+            // カーソル位置を維持
+            const cursorPosition = e.target.selectionStart;
+            e.target.setSelectionRange(cursorPosition, cursorPosition);
+        }
+        
+        // デバウンス付きで検索実行
+        debouncedSearch();
+    });
+    
     // 検索ボタンクリック時（即座に実行）
     searchButton.addEventListener('click', () => {
         clearTimeout(searchTimeout);
@@ -162,9 +199,6 @@ function setupSearchEvents() {
             performSearch();
         }
     });
-    
-    // 入力時はデバウンス付きで実行
-    searchInput.addEventListener('input', debouncedSearch);
 }
 
 // 検索実行


### PR DESCRIPTION
## Summary
- Implemented input validation to restrict the web viewer's search field to alphanumeric characters only
- Prevents Japanese characters (hiragana, katakana, kanji) and special characters from being entered
- Handles both direct keyboard input and paste operations

## Changes
- Added HTML `pattern` attribute for basic validation
- Implemented JavaScript `beforeinput` event handler to block non-alphanumeric character entry
- Added paste event filtering to remove non-alphanumeric characters from pasted content
- Maintains cursor position after filtering for better UX

## Test Plan
- [x] Tested direct keyboard input with various character types (numbers, letters, Japanese, special characters)
- [x] Tested paste operations with mixed content
- [x] Verified that security codes (4-digit numbers) can be entered correctly
- [x] Confirmed that existing tests pass without regression

## Related Issue
Fixes #114

🤖 Generated with [Claude Code](https://claude.ai/code)