### PR TITLE
feat: モバイル用ボトムアクションバーの実装

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -111,6 +111,30 @@
         </div>
     </main>
 
+    <!-- Mobile Bottom Action Bar -->
+    <div id="mobile-action-bar" class="mobile-action-bar" role="toolbar" aria-label="モバイルアクションバー">
+        <div class="mobile-search-container">
+            <svg class="mobile-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="8"></circle>
+                <path d="m21 21-4.3-4.3"></path>
+            </svg>
+            <input type="text" id="mobile-search-input" aria-label="証券コードで検索" placeholder="証券コードで検索..." pattern="[0-9A-Za-z]*" title="英数字のみ入力可能" autocomplete="off">
+        </div>
+        <button id="mobile-search-button" class="btn btn-primary mobile-btn" aria-label="検索">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="11" cy="11" r="8"></circle>
+                <path d="m21 21-4.3-4.3"></path>
+            </svg>
+        </button>
+        <button id="mobile-export-button" class="btn btn-secondary mobile-btn" aria-label="Excelエクスポート">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                <polyline points="7 10 12 15 17 10"></polyline>
+                <line x1="12" y1="15" x2="12" y2="3"></line>
+            </svg>
+        </button>
+    </div>
+
     <!-- Back to Top Button -->
     <button id="back-to-top" aria-label="トップへ戻る" title="トップへ戻る">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">

--- a/docs/script.js
+++ b/docs/script.js
@@ -282,9 +282,11 @@ function validateSecCode(code) {
 function setupSearchEvents() {
     const searchInput = document.getElementById('search-input');
     const searchButton = document.getElementById('search-button');
+    const mobileSearchInput = document.getElementById('mobile-search-input');
+    const mobileSearchButton = document.getElementById('mobile-search-button');
 
-    // Input restriction: alphanumeric only
-    searchInput.addEventListener('input', (e) => {
+    // Helper function for input restriction
+    function restrictToAlphanumeric(e) {
         const originalValue = e.target.value;
         const cleanedValue = originalValue.replace(/[^0-9A-Za-z]/g, '');
 
@@ -293,19 +295,56 @@ function setupSearchEvents() {
             e.target.value = cleanedValue;
             e.target.setSelectionRange(cursorPosition, cursorPosition);
         }
-    });
+    }
 
-    searchButton.addEventListener('click', performSearch);
-
-    searchInput.addEventListener('keypress', (e) => {
-        if (e.key === 'Enter') {
-            performSearch();
+    // Helper function to sync inputs
+    function syncSearchInputs(sourceInput, targetInput) {
+        if (targetInput) {
+            targetInput.value = sourceInput.value;
         }
-    });
+    }
+
+    // Desktop search setup
+    if (searchInput) {
+        searchInput.addEventListener('input', (e) => {
+            restrictToAlphanumeric(e);
+            syncSearchInputs(searchInput, mobileSearchInput);
+        });
+
+        searchInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                performSearch('desktop');
+            }
+        });
+    }
+
+    if (searchButton) {
+        searchButton.addEventListener('click', () => performSearch('desktop'));
+    }
+
+    // Mobile search setup
+    if (mobileSearchInput) {
+        mobileSearchInput.addEventListener('input', (e) => {
+            restrictToAlphanumeric(e);
+            syncSearchInputs(mobileSearchInput, searchInput);
+        });
+
+        mobileSearchInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                performSearch('mobile');
+            }
+        });
+    }
+
+    if (mobileSearchButton) {
+        mobileSearchButton.addEventListener('click', () => performSearch('mobile'));
+    }
 }
 
-function performSearch() {
-    const searchValue = document.getElementById('search-input').value.trim().toUpperCase();
+function performSearch(source = 'desktop') {
+    const inputId = source === 'mobile' ? 'mobile-search-input' : 'search-input';
+    const searchInput = document.getElementById(inputId);
+    const searchValue = searchInput ? searchInput.value.trim().toUpperCase() : '';
 
     const validation = validateSecCode(searchValue);
     if (!validation.valid) {
@@ -369,9 +408,15 @@ function setupBackToTopButton() {
 // ---------- Export Functionality ----------
 function setupExportButton() {
     const exportButton = document.getElementById('export-button');
-    if (!exportButton) return;
+    const mobileExportButton = document.getElementById('mobile-export-button');
 
-    exportButton.addEventListener('click', exportToExcel);
+    if (exportButton) {
+        exportButton.addEventListener('click', exportToExcel);
+    }
+
+    if (mobileExportButton) {
+        mobileExportButton.addEventListener('click', exportToExcel);
+    }
 }
 
 function exportToExcel() {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -838,12 +838,18 @@ td:not(.sticky-col) {
     color: var(--positive);
 }
 
+/* ---------- Mobile Bottom Action Bar ---------- */
+.mobile-action-bar {
+    display: none;
+}
+
 /* ---------- Mobile Responsive ---------- */
 @media (max-width: 768px) {
     :root {
         --header-height: 64px;
         --column-sec-code-width: 80px;
         --column-company-name-width: 140px;
+        --mobile-action-bar-height: 64px;
     }
 
     header {
@@ -853,8 +859,8 @@ td:not(.sticky-col) {
     .header-content {
         padding: 10px 14px;
         border-radius: var(--radius-lg);
-        flex-wrap: wrap;
-        gap: 12px;
+        flex-wrap: nowrap;
+        gap: 8px;
     }
 
     .site-title {
@@ -868,22 +874,18 @@ td:not(.sticky-col) {
     }
 
     .header-actions {
-        flex: 1;
+        flex: 0 0 auto;
         justify-content: flex-end;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
         gap: 6px;
     }
 
+    /* Hide header search on mobile - moved to bottom action bar */
     .search-container {
-        order: 10;
-        width: 100%;
+        display: none;
     }
 
-    #search-input {
-        flex: 1;
-        width: auto;
-    }
-
+    /* Hide export button text on mobile header */
     .btn-text {
         display: none;
     }
@@ -893,12 +895,12 @@ td:not(.sticky-col) {
     }
 
     main {
-        padding: calc(var(--header-height) + 16px) 8px 16px;
+        padding: calc(var(--header-height) + 16px) 8px calc(var(--mobile-action-bar-height) + 16px + env(safe-area-inset-bottom, 0px));
     }
 
     #table-container {
         border-radius: var(--radius-md);
-        max-height: calc(100vh - var(--header-height) - 32px);
+        max-height: calc(100vh - var(--header-height) - var(--mobile-action-bar-height) - 32px - env(safe-area-inset-bottom, 0px));
     }
 
     th, td {
@@ -907,7 +909,7 @@ td:not(.sticky-col) {
     }
 
     #back-to-top {
-        bottom: 16px;
+        bottom: calc(var(--mobile-action-bar-height) + 12px + env(safe-area-inset-bottom, 0px));
         right: 16px;
         width: 40px;
         height: 40px;
@@ -921,6 +923,102 @@ td:not(.sticky-col) {
     .toast {
         min-width: auto;
         max-width: none;
+    }
+
+    /* Mobile Bottom Action Bar */
+    .mobile-action-bar {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px 12px calc(12px + env(safe-area-inset-bottom, 0px));
+        background: var(--surface-secondary);
+        border-top: 1px solid var(--border-subtle);
+        box-shadow:
+            0 -1px 3px rgba(0, 0, 0, 0.04),
+            0 -2px 8px rgba(0, 0, 0, 0.03);
+        transition: background-color var(--transition-slow), border-color var(--transition-slow);
+    }
+
+    .mobile-search-container {
+        flex: 1;
+        position: relative;
+        display: flex;
+        align-items: center;
+    }
+
+    .mobile-search-icon {
+        position: absolute;
+        left: 12px;
+        color: var(--text-muted);
+        pointer-events: none;
+        transition: color var(--transition-fast);
+    }
+
+    #mobile-search-input {
+        width: 100%;
+        font-family: var(--font-mono);
+        font-size: var(--text-sm);
+        padding: 10px 12px 10px 36px;
+        background: var(--surface-tertiary);
+        border: 1px solid transparent;
+        border-radius: var(--radius-md);
+        color: var(--text-primary);
+        transition: all var(--transition-fast);
+    }
+
+    #mobile-search-input::placeholder {
+        color: var(--text-muted);
+    }
+
+    #mobile-search-input:hover {
+        background: var(--surface-primary);
+        border-color: var(--border-subtle);
+    }
+
+    #mobile-search-input:focus {
+        outline: none;
+        background: var(--surface-primary);
+        border-color: var(--accent-primary);
+        box-shadow: 0 0 0 3px var(--accent-subtle);
+    }
+
+    #mobile-search-input:focus + .mobile-search-icon,
+    .mobile-search-container:focus-within .mobile-search-icon {
+        color: var(--accent-primary);
+    }
+
+    .mobile-btn {
+        flex-shrink: 0;
+        width: 40px;
+        height: 40px;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .mobile-btn.btn-primary {
+        background: var(--accent-primary);
+        color: white;
+    }
+
+    .mobile-btn.btn-primary:hover {
+        background: var(--accent-hover);
+    }
+
+    .mobile-btn.btn-secondary {
+        background: var(--surface-tertiary);
+        border: 1px solid var(--border-subtle);
+    }
+
+    .mobile-btn.btn-secondary:hover {
+        background: var(--surface-primary);
+        border-color: var(--border-default);
     }
 }
 
@@ -947,7 +1045,7 @@ td:not(.sticky-col) {
 
 /* ---------- Print Styles ---------- */
 @media print {
-    header, #back-to-top, #toast-container {
+    header, #back-to-top, #toast-container, .mobile-action-bar {
         display: none !important;
     }
 


### PR DESCRIPTION
## Summary
- モバイルデバイス（768px以下）でボトムアクションバーを表示
- 検索入力とエクスポートボタンをボトムバーに配置
- iPhoneのノッチ対応（safe-area-inset-bottom使用）
- デスクトップとモバイルの検索入力を同期

## Changes
- `docs/index.html`: モバイル用ボトムアクションバーのHTML追加
- `docs/styles.css`: レスポンシブCSSスタイル追加（safe-area-inset対応）
- `docs/script.js`: モバイル検索とエクスポート機能のイベントハンドラ追加

## Test plan
- [x] モバイルビューポート（375x812）でボトムバー表示確認
- [x] ダークモードでの表示確認
- [x] 検索機能の動作確認
- [x] アクセシビリティ属性（role="toolbar", aria-label）確認
- [x] 印刷時に非表示になることを確認

## Screenshots
モバイルビューポートでのライトテーマ・ダークテーマ表示を確認済み

Closes #145