### PR TITLE
feat: add data density toggle, column visibility, and keyboard shortcuts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,6 +36,40 @@
                     <button id="search-button" class="btn btn-primary">検索</button>
                 </div>
 
+                <button id="density-toggle" class="btn btn-icon" aria-label="表示密度切替" title="表示密度切替 (compact/comfortable)">
+                    <svg class="icon-density-compact" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="3" y1="6" x2="21" y2="6"></line>
+                        <line x1="3" y1="10" x2="21" y2="10"></line>
+                        <line x1="3" y1="14" x2="21" y2="14"></line>
+                        <line x1="3" y1="18" x2="21" y2="18"></line>
+                    </svg>
+                    <svg class="icon-density-comfortable" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="3" y1="5" x2="21" y2="5"></line>
+                        <line x1="3" y1="12" x2="21" y2="12"></line>
+                        <line x1="3" y1="19" x2="21" y2="19"></line>
+                    </svg>
+                </button>
+
+                <div class="column-visibility-wrapper">
+                    <button id="column-toggle" class="btn btn-icon" aria-label="列表示設定" title="列表示設定" aria-haspopup="true" aria-expanded="false" aria-controls="column-dropdown">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <rect x="3" y="3" width="7" height="7"></rect>
+                            <rect x="14" y="3" width="7" height="7"></rect>
+                            <rect x="14" y="14" width="7" height="7"></rect>
+                            <rect x="3" y="14" width="7" height="7"></rect>
+                        </svg>
+                    </button>
+                    <div id="column-dropdown" class="column-dropdown" role="menu" aria-label="列表示設定">
+                        <div class="column-dropdown-header">
+                            <span>表示する列</span>
+                            <button id="column-reset" class="column-reset-btn" aria-label="すべて表示">リセット</button>
+                        </div>
+                        <div class="column-dropdown-list">
+                            <!-- Column checkboxes will be populated by JavaScript -->
+                        </div>
+                    </div>
+                </div>
+
                 <button id="export-button" class="btn btn-secondary" aria-label="Excelエクスポート">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
@@ -144,6 +178,55 @@
 
     <!-- Toast Notification Container -->
     <div id="toast-container" aria-live="polite" aria-atomic="true"></div>
+
+    <!-- Keyboard Shortcuts Modal -->
+    <div id="shortcuts-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title" hidden>
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 id="shortcuts-title">キーボードショートカット</h2>
+                <button id="shortcuts-close" class="modal-close" aria-label="閉じる">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M18 6L6 18M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="shortcut-group">
+                    <h3>検索</h3>
+                    <div class="shortcut-item">
+                        <span class="shortcut-keys">
+                            <kbd>/</kbd>
+                            <span class="shortcut-or">または</span>
+                            <kbd>Ctrl</kbd><kbd>K</kbd>
+                        </span>
+                        <span class="shortcut-desc">検索フィールドにフォーカス</span>
+                    </div>
+                    <div class="shortcut-item">
+                        <span class="shortcut-keys"><kbd>Escape</kbd></span>
+                        <span class="shortcut-desc">フォーカス解除</span>
+                    </div>
+                </div>
+                <div class="shortcut-group">
+                    <h3>表示</h3>
+                    <div class="shortcut-item">
+                        <span class="shortcut-keys"><kbd>d</kbd></span>
+                        <span class="shortcut-desc">ダークモード切替</span>
+                    </div>
+                    <div class="shortcut-item">
+                        <span class="shortcut-keys"><kbd>c</kbd></span>
+                        <span class="shortcut-desc">表示密度切替</span>
+                    </div>
+                </div>
+                <div class="shortcut-group">
+                    <h3>ヘルプ</h3>
+                    <div class="shortcut-item">
+                        <span class="shortcut-keys"><kbd>?</kbd></span>
+                        <span class="shortcut-desc">ショートカット一覧を表示</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- Scripts -->
     <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>

--- a/docs/script.js
+++ b/docs/script.js
@@ -132,11 +132,423 @@ class ThemeManager {
     }
 }
 
+// ---------- Density Management ----------
+class DensityManager {
+    constructor() {
+        this.toggle = document.getElementById('density-toggle');
+        this.init();
+    }
+
+    init() {
+        let savedDensity = null;
+        try {
+            savedDensity = localStorage.getItem('density');
+        } catch (e) {
+            console.warn('localStorage unavailable:', e);
+        }
+
+        if (savedDensity) {
+            this.setDensity(savedDensity);
+        } else {
+            this.setDensity('comfortable');
+        }
+
+        if (this.toggle) {
+            this.toggle.addEventListener('click', () => this.toggleDensity());
+        }
+    }
+
+    setDensity(density) {
+        document.documentElement.setAttribute('data-density', density);
+        try {
+            localStorage.setItem('density', density);
+        } catch (e) {
+            console.warn('localStorage unavailable:', e);
+        }
+    }
+
+    toggleDensity() {
+        const currentDensity = document.documentElement.getAttribute('data-density');
+        const newDensity = currentDensity === 'compact' ? 'comfortable' : 'compact';
+        this.setDensity(newDensity);
+
+        // Announce change to screen readers
+        const message = newDensity === 'compact' ? 'コンパクト表示に切替' : '標準表示に切替';
+        this.announceChange(message);
+    }
+
+    announceChange(message) {
+        const announcement = document.createElement('div');
+        announcement.setAttribute('role', 'status');
+        announcement.setAttribute('aria-live', 'polite');
+        announcement.className = 'sr-only';
+        announcement.textContent = message;
+        document.body.appendChild(announcement);
+        setTimeout(() => announcement.remove(), 1000);
+    }
+}
+
+// ---------- Column Visibility Management ----------
+class ColumnVisibilityManager {
+    constructor() {
+        this.toggleBtn = document.getElementById('column-toggle');
+        this.dropdown = document.getElementById('column-dropdown');
+        this.resetBtn = document.getElementById('column-reset');
+        this.dropdownList = this.dropdown?.querySelector('.column-dropdown-list');
+
+        // Column definitions with labels
+        this.columns = [
+            { index: 0, key: 'secCode', label: '証券コード', required: true },
+            { index: 1, key: 'filerName', label: '企業名称', required: true },
+            { index: 2, key: 'periodEnd', label: '決算期', required: false },
+            { index: 3, key: 'stockPrice', label: '株価', required: false },
+            { index: 4, key: 'netSales', label: '売上高', required: false },
+            { index: 5, key: 'employees', label: '従業員数', required: false },
+            { index: 6, key: 'operatingIncome', label: '営業利益', required: false },
+            { index: 7, key: 'operatingIncomeRate', label: '営業利益率', required: false },
+            { index: 8, key: 'ordinaryIncome', label: '経常利益', required: false },
+            { index: 9, key: 'ordinaryIncomeRate', label: '経常利益率', required: false },
+            { index: 10, key: 'ebitda', label: 'EBITDA', required: false },
+            { index: 11, key: 'ebitdaMargin', label: 'EBITDAマージン', required: false },
+            { index: 12, key: 'marketCapitalization', label: '時価総額', required: false },
+            { index: 13, key: 'per', label: 'PER', required: false },
+            { index: 14, key: 'ev', label: '企業価値', required: false },
+            { index: 15, key: 'evPerEbitda', label: 'EV/EBITDA', required: false },
+            { index: 16, key: 'pbr', label: 'PBR', required: false },
+            { index: 17, key: 'equity', label: '純資産合計', required: false },
+            { index: 18, key: 'debt', label: 'ネット有利子負債', required: false },
+            { index: 19, key: 'issuedDate', label: 'EDINET提出日', required: false },
+            { index: 20, key: 'retrievedDate', label: '最終更新日', required: false }
+        ];
+
+        this.visibilityState = {};
+        this.init();
+    }
+
+    init() {
+        // Load saved visibility state
+        let savedState = null;
+        try {
+            const savedJson = localStorage.getItem('columnVisibility');
+            if (savedJson) {
+                const parsed = JSON.parse(savedJson);
+                // Validate that parsed data is a plain object with boolean values
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    savedState = parsed;
+                }
+            }
+        } catch (e) {
+            console.warn('localStorage unavailable or invalid:', e);
+        }
+
+        // Initialize visibility state
+        this.columns.forEach(col => {
+            if (savedState && typeof savedState[col.key] === 'boolean') {
+                this.visibilityState[col.key] = col.required ? true : savedState[col.key];
+            } else {
+                this.visibilityState[col.key] = true;
+            }
+        });
+
+        this.buildDropdownList();
+        this.setupEventListeners();
+        this.applyVisibility();
+    }
+
+    buildDropdownList() {
+        if (!this.dropdownList) return;
+
+        this.dropdownList.innerHTML = '';
+
+        this.columns.forEach(col => {
+            const item = document.createElement('label');
+            item.className = `column-checkbox-item${col.required ? ' disabled' : ''}`;
+            item.setAttribute('role', 'menuitemcheckbox');
+            item.setAttribute('aria-checked', String(this.visibilityState[col.key]));
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.checked = this.visibilityState[col.key];
+            checkbox.disabled = col.required;
+            checkbox.dataset.columnKey = col.key;
+
+            const label = document.createElement('span');
+            label.textContent = col.label;
+
+            item.appendChild(checkbox);
+            item.appendChild(label);
+            this.dropdownList.appendChild(item);
+
+            if (!col.required) {
+                checkbox.addEventListener('change', (e) => {
+                    this.visibilityState[col.key] = e.target.checked;
+                    item.setAttribute('aria-checked', String(e.target.checked));
+                    this.saveState();
+                    this.applyVisibility();
+                });
+            }
+        });
+    }
+
+    setupEventListeners() {
+        if (this.toggleBtn) {
+            this.toggleBtn.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.toggleDropdown();
+            });
+        }
+
+        if (this.resetBtn) {
+            this.resetBtn.addEventListener('click', () => {
+                this.resetAll();
+            });
+        }
+
+        // Close dropdown when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!this.dropdown?.contains(e.target) && !this.toggleBtn?.contains(e.target)) {
+                this.closeDropdown();
+            }
+        });
+
+        // Close dropdown on Escape
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && this.dropdown?.classList.contains('open')) {
+                this.closeDropdown();
+            }
+        });
+    }
+
+    toggleDropdown() {
+        const isOpen = this.dropdown?.classList.contains('open');
+        if (isOpen) {
+            this.closeDropdown();
+        } else {
+            this.openDropdown();
+        }
+    }
+
+    openDropdown() {
+        this.dropdown?.classList.add('open');
+        this.toggleBtn?.setAttribute('aria-expanded', 'true');
+    }
+
+    closeDropdown() {
+        this.dropdown?.classList.remove('open');
+        this.toggleBtn?.setAttribute('aria-expanded', 'false');
+    }
+
+    resetAll() {
+        this.columns.forEach(col => {
+            this.visibilityState[col.key] = true;
+        });
+
+        // Update checkboxes and aria-checked attributes
+        const items = this.dropdownList?.querySelectorAll('.column-checkbox-item');
+        items?.forEach(item => {
+            const checkbox = item.querySelector('input[type="checkbox"]');
+            if (checkbox) {
+                checkbox.checked = true;
+            }
+            item.setAttribute('aria-checked', 'true');
+        });
+
+        this.saveState();
+        this.applyVisibility();
+    }
+
+    saveState() {
+        try {
+            localStorage.setItem('columnVisibility', JSON.stringify(this.visibilityState));
+        } catch (e) {
+            console.warn('localStorage unavailable:', e);
+        }
+    }
+
+    applyVisibility() {
+        const table = document.getElementById('data-table');
+        if (!table) return;
+
+        this.columns.forEach(col => {
+            const isVisible = this.visibilityState[col.key];
+
+            // Apply to header
+            const th = table.querySelector(`thead tr th:nth-child(${col.index + 1})`);
+            if (th) {
+                th.setAttribute('data-hidden', !isVisible);
+            }
+
+            // Apply to all body cells
+            const tds = table.querySelectorAll(`tbody tr td:nth-child(${col.index + 1})`);
+            tds.forEach(td => {
+                td.setAttribute('data-hidden', !isVisible);
+            });
+        });
+    }
+}
+
+// ---------- Keyboard Shortcuts Management ----------
+class KeyboardShortcutsManager {
+    constructor(themeManager, densityManager) {
+        this.themeManager = themeManager;
+        this.densityManager = densityManager;
+        this.modal = document.getElementById('shortcuts-modal');
+        this.closeBtn = document.getElementById('shortcuts-close');
+        this.previousActiveElement = null;
+        this.handleModalKeydown = this.handleModalKeydown.bind(this);
+        this.init();
+    }
+
+    init() {
+        this.setupKeyboardListeners();
+        this.setupModalListeners();
+    }
+
+    handleModalKeydown(e) {
+        if (e.key !== 'Tab') return;
+
+        const focusableElements = this.modal.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey && document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+        } else if (!e.shiftKey && document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+        }
+    }
+
+    setupKeyboardListeners() {
+        document.addEventListener('keydown', (e) => {
+            // Ignore if user is typing in an input field
+            const isTyping = e.target.tagName === 'INPUT' ||
+                             e.target.tagName === 'TEXTAREA' ||
+                             e.target.isContentEditable;
+
+            // Special handling for Escape - always allow
+            if (e.key === 'Escape') {
+                // Close modal if open
+                if (!this.modal?.hidden) {
+                    this.closeModal();
+                    return;
+                }
+
+                // Blur search input
+                const searchInput = document.getElementById('search-input');
+                const mobileSearchInput = document.getElementById('mobile-search-input');
+                if (document.activeElement === searchInput || document.activeElement === mobileSearchInput) {
+                    document.activeElement.blur();
+                }
+                return;
+            }
+
+            // Don't process other shortcuts if typing
+            if (isTyping) return;
+
+            // ? - Show shortcuts modal
+            if (e.key === '?' && e.shiftKey) {
+                e.preventDefault();
+                this.toggleModal();
+                return;
+            }
+
+            // / or Ctrl+K (Cmd+K on macOS) - Focus search
+            if (e.key === '/' || ((e.ctrlKey || e.metaKey) && e.key === 'k')) {
+                e.preventDefault();
+                this.focusSearch();
+                return;
+            }
+
+            // d - Toggle dark mode
+            if (e.key === 'd') {
+                e.preventDefault();
+                this.themeManager?.toggleTheme();
+                return;
+            }
+
+            // c - Toggle density
+            if (e.key === 'c') {
+                e.preventDefault();
+                this.densityManager?.toggleDensity();
+                return;
+            }
+        });
+    }
+
+    setupModalListeners() {
+        // Close button
+        this.closeBtn?.addEventListener('click', () => {
+            this.closeModal();
+        });
+
+        // Click outside modal content to close
+        this.modal?.addEventListener('click', (e) => {
+            if (e.target === this.modal) {
+                this.closeModal();
+            }
+        });
+    }
+
+    focusSearch() {
+        // Try desktop search first, fall back to mobile
+        const searchInput = document.getElementById('search-input');
+        const mobileSearchInput = document.getElementById('mobile-search-input');
+
+        // Check if on mobile (using media query)
+        const isMobile = window.matchMedia('(max-width: 768px)').matches;
+
+        if (isMobile && mobileSearchInput) {
+            mobileSearchInput.focus();
+        } else if (searchInput) {
+            searchInput.focus();
+        }
+    }
+
+    toggleModal() {
+        if (this.modal?.hidden) {
+            this.openModal();
+        } else {
+            this.closeModal();
+        }
+    }
+
+    openModal() {
+        if (!this.modal) return;
+        this.previousActiveElement = document.activeElement;
+        this.modal.hidden = false;
+        // Add focus trap
+        this.modal.addEventListener('keydown', this.handleModalKeydown);
+        // Focus close button for accessibility
+        setTimeout(() => {
+            this.closeBtn?.focus();
+        }, 100);
+    }
+
+    closeModal() {
+        if (!this.modal) return;
+        this.modal.hidden = true;
+        this.modal.removeEventListener('keydown', this.handleModalKeydown);
+        // Restore focus to previous element
+        this.previousActiveElement?.focus();
+    }
+}
+
 // ---------- Initialization ----------
+let themeManager;
+let densityManager;
+let columnVisibilityManager;
+
 document.addEventListener('DOMContentLoaded', async () => {
     // Initialize systems
     toastNotification = new ToastNotification();
-    new ThemeManager();
+    themeManager = new ThemeManager();
+    densityManager = new DensityManager();
+    columnVisibilityManager = new ColumnVisibilityManager();
+    new KeyboardShortcutsManager(themeManager, densityManager);
 
     // Load data and setup UI
     await loadData();
@@ -222,6 +634,11 @@ function displayData(data) {
 
         tbody.appendChild(row);
     });
+
+    // Reapply column visibility after data render
+    if (columnVisibilityManager) {
+        columnVisibilityManager.applyVisibility();
+    }
 }
 
 // ---------- Formatting Functions ----------

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1100,3 +1100,403 @@ a:focus:not(:focus-visible) {
 .skip-link:focus {
     top: 0;
 }
+
+/* Screen reader only - for accessibility announcements */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* ---------- Data Density Toggle ---------- */
+.icon-density-compact,
+.icon-density-comfortable {
+    transition: transform var(--transition-base), opacity var(--transition-base);
+}
+
+/* Show compact icon when in comfortable mode (to switch to compact) */
+[data-density="comfortable"] .icon-density-comfortable,
+:not([data-density]) .icon-density-comfortable {
+    display: none;
+}
+
+[data-density="comfortable"] .icon-density-compact,
+:not([data-density]) .icon-density-compact {
+    display: block;
+}
+
+/* Show comfortable icon when in compact mode (to switch to comfortable) */
+[data-density="compact"] .icon-density-compact {
+    display: none;
+}
+
+[data-density="compact"] .icon-density-comfortable {
+    display: block;
+}
+
+/* Compact Mode Styles */
+[data-density="compact"] td {
+    padding: 6px 8px;
+    font-size: var(--text-xs);
+}
+
+[data-density="compact"] th {
+    padding: 10px 8px;
+    font-size: 0.6875rem;
+}
+
+[data-density="compact"] .unit {
+    font-size: 0.625rem;
+}
+
+/* Comfortable Mode Styles (default) */
+[data-density="comfortable"] td,
+:not([data-density]) td {
+    padding: 12px;
+    font-size: var(--text-sm);
+}
+
+[data-density="comfortable"] th,
+:not([data-density]) th {
+    padding: 14px 12px;
+    font-size: var(--text-xs);
+}
+
+/* ---------- Column Visibility Dropdown ---------- */
+.column-visibility-wrapper {
+    position: relative;
+}
+
+.column-dropdown {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    width: 220px;
+    background: var(--surface-secondary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-4px);
+    transition: all var(--transition-fast);
+    z-index: 1001;
+}
+
+.column-dropdown.open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.column-dropdown-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.column-dropdown-header span {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.column-reset-btn {
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--accent-primary);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: var(--radius-sm);
+    transition: background-color var(--transition-fast);
+}
+
+.column-reset-btn:hover {
+    background: var(--accent-subtle);
+}
+
+.column-dropdown-list {
+    max-height: 320px;
+    overflow-y: auto;
+    padding: 8px 0;
+}
+
+.column-dropdown-list::-webkit-scrollbar {
+    width: 6px;
+}
+
+.column-dropdown-list::-webkit-scrollbar-thumb {
+    background: var(--border-default);
+    border-radius: 3px;
+}
+
+.column-checkbox-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    transition: background-color var(--transition-fast);
+}
+
+.column-checkbox-item:hover {
+    background: var(--row-hover);
+}
+
+.column-checkbox-item input[type="checkbox"] {
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 1px solid var(--border-default);
+    border-radius: 4px;
+    background: var(--surface-secondary);
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: all var(--transition-fast);
+}
+
+.column-checkbox-item input[type="checkbox"]:checked {
+    background: var(--accent-primary);
+    border-color: var(--accent-primary);
+}
+
+.column-checkbox-item input[type="checkbox"]:checked::after {
+    content: '';
+    position: absolute;
+    left: 4.5px;
+    top: 1.5px;
+    width: 4px;
+    height: 8px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+.column-checkbox-item input[type="checkbox"]:focus-visible {
+    outline: 2px solid var(--accent-primary);
+    outline-offset: 2px;
+}
+
+.column-checkbox-item span {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.column-checkbox-item.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.column-checkbox-item.disabled input[type="checkbox"] {
+    cursor: not-allowed;
+}
+
+/* Hidden column styles */
+th[data-hidden="true"],
+td[data-hidden="true"] {
+    display: none;
+}
+
+/* ---------- Keyboard Shortcuts Modal ---------- */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.6);
+    backdrop-filter: blur(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--transition-base), visibility var(--transition-base);
+}
+
+.modal-overlay:not([hidden]) {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-overlay[hidden] {
+    display: flex;
+}
+
+.modal-content {
+    background: var(--surface-secondary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    width: 100%;
+    max-width: 400px;
+    margin: 16px;
+    transform: scale(0.95);
+    transition: transform var(--transition-base);
+}
+
+.modal-overlay:not([hidden]) .modal-content {
+    transform: scale(1);
+}
+
+.modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.modal-header h2 {
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.modal-close {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: all var(--transition-fast);
+}
+
+.modal-close:hover {
+    background: var(--surface-tertiary);
+    color: var(--text-primary);
+}
+
+.modal-body {
+    padding: 16px 20px 20px;
+}
+
+.shortcut-group {
+    margin-bottom: 20px;
+}
+
+.shortcut-group:last-child {
+    margin-bottom: 0;
+}
+
+.shortcut-group h3 {
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 10px;
+}
+
+.shortcut-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+}
+
+.shortcut-keys {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.shortcut-or {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    margin: 0 4px;
+}
+
+kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 24px;
+    padding: 0 8px;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: var(--surface-tertiary);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    box-shadow: 0 1px 0 var(--border-default);
+}
+
+.shortcut-desc {
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+}
+
+/* Dark mode adjustments for modal */
+[data-theme="dark"] .modal-overlay {
+    background: rgba(0, 0, 0, 0.7);
+}
+
+[data-theme="dark"] kbd {
+    background: var(--surface-tertiary);
+    border-color: var(--border-default);
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
+}
+
+/* ---------- Mobile Adjustments for New Features ---------- */
+@media (max-width: 768px) {
+    /* Hide column visibility and density on small screens - keep essential actions only */
+    #density-toggle,
+    .column-visibility-wrapper {
+        display: none;
+    }
+
+    .modal-content {
+        max-width: none;
+        margin: 12px;
+        border-radius: var(--radius-md);
+    }
+
+    .modal-header {
+        padding: 14px 16px;
+    }
+
+    .modal-header h2 {
+        font-size: var(--text-base);
+    }
+
+    .modal-body {
+        padding: 14px 16px 16px;
+    }
+
+    .shortcut-item {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    /* Compact density adjustments for mobile */
+    [data-density="compact"] td {
+        padding: 6px 6px;
+    }
+
+    [data-density="compact"] th {
+        padding: 8px 6px;
+    }
+}


### PR DESCRIPTION
## Summary
- Implement data density toggle (compact/comfortable) with localStorage persistence
- Add column visibility control dropdown to show/hide table columns
- Implement keyboard shortcuts for improved usability

## Features

### Data Density Toggle
- Toggle button in header to switch between compact and comfortable table density
- Compact: smaller padding and font for more data visibility
- Comfortable: standard padding (default)
- Settings persisted to localStorage

### Column Visibility Control
- Dropdown menu to show/hide any of 21 table columns
- Required columns (証券コード, 企業名称) cannot be hidden
- Reset button to restore all columns
- Settings persisted to localStorage

### Keyboard Shortcuts
- `/` or `Ctrl+K` (or `Cmd+K` on macOS): Focus search field
- `Escape`: Unfocus search / close modals
- `d`: Toggle dark mode
- `c`: Toggle density
- `?`: Show shortcuts help modal

## Accessibility
- Focus trap in keyboard shortcuts modal
- Screen reader announcements for density changes
- Proper ARIA attributes (aria-controls, aria-checked, role="menuitemcheckbox")
- Support for macOS Cmd+K shortcut

## Test Plan
- [x] Verify density toggle switches between compact/comfortable modes
- [x] Verify density setting persists across page reloads
- [x] Verify column visibility dropdown opens/closes correctly
- [x] Verify columns can be hidden/shown via checkboxes
- [x] Verify column visibility persists across page reloads
- [x] Verify keyboard shortcuts work (/, Ctrl+K, d, c, ?)
- [x] Verify Escape closes modals and unfocuses search
- [x] Verify modal focus trap works correctly
- [x] Tested with Playwright browser automation

Closes #146