### PR TITLE
chore: add .playwright-mcp/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ analyze_*.py
 *.log
 XBRL_*.md
 xbrl_*_investigation_*.json
+
+# Playwright MCP
+# Browser automation outputs (screenshots, traces, videos, sessions)
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Add `.playwright-mcp/` directory to `.gitignore`
- Excludes Playwright MCP generated files (screenshots, traces, videos, sessions) from version control

## Test plan
- [x] Verify `.playwright-mcp/` no longer appears in `git status`
- [x] Comment style matches existing `.gitignore` patterns

Closes #151