### PR TITLE
feat: detect delisted companies and highlight them in web viewer

### DIFF
--- a/.claude/context/changelog.md
+++ b/.claude/context/changelog.md
@@ -113,6 +113,30 @@
   - pointer-eventsによる適切なイベント処理
   - z-indexによるレイヤー管理（z-index: 10000）
 
+### 上場廃止企業の検出とWeb UI表示（2026年4月）
+- **概要**: JPX公開の「東証上場銘柄一覧」(`data_j.xls`) との差分で上場廃止企業を検出し、`data/edinet.json`と Web ビューアで視覚的に区別する
+- **背景**: EDINETは有価証券報告書のみを提供し、上場廃止情報を持たない。有報を提出しなくなった企業は fetcher から消えるが、過去の `data/jsons/*.json` に残ったデータは「ゾンビ」化していた
+- **検出ロジック**:
+  - `delisted = (observed_secs - regional_skip) - jpx_listed`
+  - `observed_secs`: `data/jsons/*.json` で過去に観測された全 secCode
+  - `jpx_listed`: JPX `data_j.xls` から抽出した現役の東証上場 secCode
+  - `regional_skip`: `config/stock_exchange_mapping.yml` 登録コード（地方取引所単独上場銘柄のため JPX データに含まれず、判定対象から**除外**する）
+- **新規ファイル**:
+  - `lib/delisted_detector.py` - 差分計算ロジック
+  - `bin/update_delisted_companies.py` - JPX 取得・YAML 更新（Fail-safe エスカレーション付き）
+  - `data/delisted_companies.yml` - 上場廃止企業の永続化 YAML
+  - `tests/test_delisted_detector.py`, `tests/test_consolidate_delisted.py`
+- **変更ファイル**:
+  - `bin/consolidate_documents.py` - `--delisted` 引数で yml を読み、各 company に `isDelisted` / `delistedDate` フィールドを付与
+  - `docs/script.js` / `docs/styles.css` / `docs/index.html` - `.delisted-row` クラスと `廃止` バッジ、Excel エクスポート列追加
+  - `.github/workflows/edinet-fetcher.yml` - fetch と consolidate の間に update ステップ挿入、`concurrency` グループ追加
+  - `pyproject.toml` / `requirements.txt` - `xlrd==1.2.0` を明示的にピン（xlrd 2.x 以降は `.xls` 非対応）
+- **重要な技術判断**:
+  - **pandas 経由ではなく xlrd を直接呼ぶ**: pandas 2.x は `xlrd>=2.0.1` を要求するが xlrd 2.x は `.xls` 未対応という矛盾のため、`xlrd.open_workbook()` を直接呼ぶ
+  - **`stock_exchange_mapping.yml` は判定スキップリスト（exclusion）として使用**: ホワイトリスト扱いはしない（mapping 未登録の地方単独上場銘柄は誤検出される可能性があるが、それは既存の quarterly update 運用問題に還元される）
+  - **JPX 取得失敗の段階的エスカレーション**: 1 連続失敗→stderr warning、2 連続→`$GITHUB_STEP_SUMMARY` に警告、3 連続→`exit 1` で step を失敗させる。連続失敗カウンタは `metadata.consecutive_failures` に永続化
+- **初期導入時の検出数**: 約 200 件（直近の TOB/MBO による上場廃止が大半。e.g., イオンモール, SCSK, NTTデータグループ, ベネッセHD, ＳＢＩレオスひふみ 等）
+
 ## 今後の改善予定
 
 ### 技術的改善

--- a/.claude/context/product-requirements.md
+++ b/.claude/context/product-requirements.md
@@ -46,6 +46,8 @@ python fetch_edinet_financial_documents.py --date YYYY-MM-DD --outputdir data/js
 | ordinaryIncome | 経常利益（2025-07追加） | 1300000000 |
 | ordinaryIncomeRate | 経常利益率（2025-07追加） | 8.67 |
 | issuedDate | 有価証券報告書提出日（2025-07追加） | 2024-09-30 |
+| isDelisted | 上場廃止フラグ（2026-04追加） | true / false |
+| delistedDate | 上場廃止検知日（2026-04追加） | 2026-04-11 |
 | characteristic | 企業特色（Yahoo Finance優先） | 【特色】IT企業向けクラウドサービス |
 | （他多数） | | |
 
@@ -54,11 +56,28 @@ python fetch_edinet_financial_documents.py --date YYYY-MM-DD --outputdir data/js
 #### 基本機能
 - 複数のJSONファイルを統合
 - 重複企業は最新データを保持
+- 上場廃止企業（`data/delisted_companies.yml`）の情報を付与（2026-04追加）
 - 統合データをJSON形式で出力
 
 #### コマンドライン仕様
 ```bash
-python consolidate_documents.py --inputdir data/jsons/ --output data/edinet.json
+python consolidate_documents.py --inputdir data/jsons/ --output data/edinet.json \
+    --delisted data/delisted_companies.yml
+```
+
+### 2.3 上場廃止検出ツール（2026-04追加）
+
+#### 基本機能
+- JPX「東証上場銘柄一覧」(`data_j.xls`) との差分で上場廃止企業を検出
+- `data/delisted_companies.yml` に永続化（初回検出日を保存）
+- JPX 取得失敗時は段階的エスカレーション（1 連続 warning / 2 連続 GitHub Actions step summary / 3 連続 exit 1）
+
+#### コマンドライン仕様
+```bash
+python bin/update_delisted_companies.py \
+    --jsonsdir data/jsons \
+    --mapping config/stock_exchange_mapping.yml \
+    --output data/delisted_companies.yml
 ```
 
 ## 3. 技術要件

--- a/.github/workflows/edinet-fetcher.yml
+++ b/.github/workflows/edinet-fetcher.yml
@@ -7,10 +7,15 @@ on:
   # 手動実行も可能にする
   workflow_dispatch:
 
+# delisted_companies.yml の更新と commit が並行実行で競合しないよう直列化
+concurrency:
+  group: edinet-fetcher
+  cancel-in-progress: false
+
 jobs:
   run-scripts:
     runs-on: ubuntu-latest
-    
+
     steps:
     # リポジトリのコードをチェックアウト
     - name: Checkout repository
@@ -41,11 +46,23 @@ jobs:
       env:
         EDINET_API_KEY: ${{ secrets.EDINET_API_KEY }}
       run: uv run python bin/fetch_edinet_financial_documents.py --date $(date -d "yesterday" '+%Y-%m-%d') --outputdir data/jsons --api-key $EDINET_API_KEY
-    
+
+    # JPX data_j.xls との差分で上場廃止銘柄を検出し delisted_companies.yml を更新
+    # 失敗時は段階的エスカレーション（1→warning / 2→step summary / 3→exit 1）
+    - name: Update delisted companies
+      run: |
+        uv run python bin/update_delisted_companies.py \
+          --jsonsdir data/jsons \
+          --mapping config/stock_exchange_mapping.yml \
+          --output data/delisted_companies.yml
+
     # 2つ目のスクリプトを実行
     - name: Consolidate documents
       run: |
-        uv run python bin/consolidate_documents.py --inputdir data/jsons/ --output data/edinet.json
+        uv run python bin/consolidate_documents.py \
+          --inputdir data/jsons/ \
+          --output data/edinet.json \
+          --delisted data/delisted_companies.yml
         # docs配下にもコピー（GitHub Pages用）
         cp data/edinet.json docs/data.json
     

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This system provides comprehensive financial data extraction and analysis capabi
 - **Automated Data Collection**: Daily extraction from EDINET API with intelligent retry mechanisms
 - **Comprehensive Metrics**: Extraction of 25+ key financial indicators including P&L, balance sheet, and market data
 - **Yahoo Finance Integration**: Enriched data with real-time stock prices and market metrics
+- **Delisted Company Detection**: Automatically flags companies that no longer appear in the JPX listing, based on differences against the JPX `data_j.xls` snapshot
 - **Flexible Filtering**: Target specific companies using security codes
 - **Data Consolidation**: Merge multiple daily extracts into unified datasets
 - **Enterprise Value Calculations**: Automated EV, EBITDA, and EV/EBITDA calculations
@@ -125,10 +126,24 @@ Consolidates multiple daily JSON files into a single file.
 - `--output`: Output file path
 
 **Optional Parameters:**
+- `--delisted`: Path to the delisted companies YAML file (default: `data/delisted_companies.yml`). Adds `isDelisted` and `delistedDate` fields to each company in the output.
 - `--summary`: Display summary statistics
 - `--verbose, -v`: Enable detailed logging
 
 **Output:** Creates consolidated JSON file
+
+### update_delisted_companies.py
+
+Detects delisted companies by comparing every securities code ever observed in `data/jsons/*.json` against the current JPX listing (`data_j.xls`), excluding regional-exchange single-listed stocks. Updates `data/delisted_companies.yml` in place, preserving the first detection date for codes already known to be delisted.
+
+```bash
+uv run python bin/update_delisted_companies.py \
+  --jsonsdir data/jsons \
+  --mapping config/stock_exchange_mapping.yml \
+  --output data/delisted_companies.yml
+```
+
+**Fail-safe:** If the JPX file fails to download, a consecutive-failure counter is maintained in the YAML metadata. After 1 failure the script emits a warning; after 2 it writes to `$GITHUB_STEP_SUMMARY` (if set); after 3 it exits with status 1 so the CI step fails visibly.
 
 ## Extracted Financial Metrics
 
@@ -160,6 +175,8 @@ Consolidates multiple daily JSON files into a single file.
 | eps | Earnings per share | Number |
 | cash | Cash and cash equivalents | Number |
 | issuedDate | Securities report submission date | String |
+| isDelisted | Delisted flag (2026-04 added) | Boolean |
+| delistedDate | Delisted detection date (YYYY-MM-DD) | String |
 | ebitda | EBITDA | Number |
 | ebitdaMargin | EBITDA margin (%) | Number |
 | ev | Enterprise value | Number |

--- a/bin/consolidate_documents.py
+++ b/bin/consolidate_documents.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Any, Optional
 from collections import defaultdict
 
+import yaml
+
 # Add parent directory to path to access lib module
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -29,12 +31,31 @@ from lib.edinet_common import setup_logging, ensure_output_directory
 logger = logging.getLogger(__name__)
 
 
+def load_delisted_map(yaml_path: str) -> Dict[str, Dict[str, Any]]:
+    """
+    Load the delisted companies YAML into a {secCode: {detectedDate, name, ...}} map.
+
+    Returns an empty dict if the file does not exist or cannot be parsed.
+    """
+    if not yaml_path or not os.path.exists(yaml_path):
+        return {}
+    try:
+        with open(yaml_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning(f"Could not load delisted yaml {yaml_path}: {e}")
+        return {}
+    delisted = data.get('delisted', {}) or {}
+    return {str(code): (info or {}) for code, info in delisted.items()}
+
+
 class DataConsolidator:
     """Consolidates financial data from multiple JSON files"""
-    
-    def __init__(self, input_directory: str):
+
+    def __init__(self, input_directory: str, delisted_yaml_path: Optional[str] = None):
         self.input_directory = input_directory
         self.consolidated_data = {}
+        self.delisted_yaml_path = delisted_yaml_path
         self.logger = logging.getLogger(__name__)
         
     def consolidate_files(self) -> List[Dict[str, Any]]:
@@ -104,8 +125,32 @@ class DataConsolidator:
                 if len(company_entries) > 1:
                     self.logger.debug(f"  Consolidated {len(company_entries)} entries for company {sec_code}")
         
+        # Annotate delisted companies if a yaml path was supplied.
+        if self.delisted_yaml_path:
+            self._annotate_delisted(consolidated_companies)
+
         self.logger.info(f"Consolidation complete: {len(consolidated_companies)} unique companies")
         return consolidated_companies
+
+    def _annotate_delisted(self, companies: List[Dict[str, Any]]) -> None:
+        """
+        Attach ``isDelisted`` and ``delistedDate`` fields to each company
+        based on the delisted_companies.yml file.
+        """
+        delisted_map = load_delisted_map(self.delisted_yaml_path)
+        annotated = 0
+        for company in companies:
+            sec_code = company.get('secCode')
+            if sec_code and sec_code in delisted_map:
+                company['isDelisted'] = True
+                company['delistedDate'] = delisted_map[sec_code].get('detectedDate')
+                annotated += 1
+            else:
+                company['isDelisted'] = False
+                company['delistedDate'] = None
+        self.logger.info(
+            f"Annotated {annotated} delisted companies from {self.delisted_yaml_path}"
+        )
     
     def _filter_files_by_date(self, json_files: List[str]) -> List[str]:
         """
@@ -319,6 +364,11 @@ def main():
     parser = argparse.ArgumentParser(description="Consolidate financial data from multiple JSON files")
     parser.add_argument("--inputdir", required=True, help="Input directory containing JSON files")
     parser.add_argument("--output", required=True, help="Output file path")
+    parser.add_argument(
+        "--delisted",
+        default="data/delisted_companies.yml",
+        help="Delisted companies YAML (for annotating isDelisted/delistedDate)",
+    )
     parser.add_argument("--summary", action="store_true", help="Display summary report")
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
     
@@ -337,7 +387,7 @@ def main():
             sys.exit(1)
         
         # Initialize consolidator
-        consolidator = DataConsolidator(args.inputdir)
+        consolidator = DataConsolidator(args.inputdir, delisted_yaml_path=args.delisted)
         
         logger.info("Starting data consolidation...")
         

--- a/bin/update_delisted_companies.py
+++ b/bin/update_delisted_companies.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Update data/delisted_companies.yml by detecting newly delisted companies.
+
+Fetches JPX "東証上場銘柄一覧" (data_j.xls), compares it with every secCode
+ever observed in data/jsons/*.json, excludes regional-exchange single-listed
+stocks (stock_exchange_mapping.yml), and writes the resulting delisted set
+to data/delisted_companies.yml.
+
+Fail-safe with escalation on JPX fetch failure:
+    1 consecutive failure  -> warning to stderr, exit 0
+    2 consecutive failures -> warning + GitHub Actions step summary, exit 0
+    3 consecutive failures -> exit 1 (fails the workflow step)
+
+Usage:
+    python bin/update_delisted_companies.py \
+        --jsonsdir data/jsons \
+        --mapping config/stock_exchange_mapping.yml \
+        --output data/delisted_companies.yml
+"""
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+
+import requests
+import yaml
+
+# Allow running the script directly (bin/update_delisted_companies.py).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lib.delisted_detector import (
+    JPX_DATA_J_URL,
+    compute_delisted,
+    load_jpx_listed_set,
+    load_observed_secs_from_jsons,
+    load_regional_skip_set,
+    merge_delisted_yaml,
+    record_failure,
+    today_iso,
+)
+from lib.edinet_common import ensure_output_directory, setup_logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_AGENT = (
+    "edinet-delisted-detector/0.1 (+https://github.com/mikanmarusan/edinet)"
+)
+DEFAULT_TIMEOUT = 60  # seconds
+DOWNLOAD_RETRIES = 2
+
+
+def download_jpx_xls(url: str, user_agent: str = DEFAULT_USER_AGENT) -> str:
+    """
+    Download the JPX data_j.xls file to a temporary path.
+
+    Retries up to DOWNLOAD_RETRIES times on transient failures.
+
+    Returns:
+        Path to a temporary file containing the downloaded bytes.
+
+    Raises:
+        RuntimeError: If the download fails after all retries.
+    """
+    last_exc = None
+    for attempt in range(1, DOWNLOAD_RETRIES + 2):
+        try:
+            logger.info("Downloading JPX listing from %s (attempt %d)", url, attempt)
+            response = requests.get(
+                url,
+                headers={"User-Agent": user_agent},
+                timeout=DEFAULT_TIMEOUT,
+            )
+            response.raise_for_status()
+            if not response.content:
+                raise RuntimeError("Empty response body")
+
+            tmp = tempfile.NamedTemporaryFile(suffix=".xls", delete=False)
+            tmp.write(response.content)
+            tmp.close()
+            logger.info(
+                "Downloaded %d bytes (Content-Type=%s) to %s",
+                len(response.content),
+                response.headers.get("Content-Type", "unknown"),
+                tmp.name,
+            )
+            return tmp.name
+        except Exception as e:  # noqa: BLE001 - we want to retry any error
+            last_exc = e
+            logger.warning("JPX download attempt %d failed: %s", attempt, e)
+    raise RuntimeError(f"Failed to download JPX listing after {DOWNLOAD_RETRIES + 1} attempts: {last_exc}")
+
+
+def load_existing_yaml(output_path: str) -> dict:
+    """Load the current delisted_companies.yml, returning {} if absent."""
+    if not os.path.exists(output_path):
+        return {}
+    try:
+        with open(output_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+            return data if isinstance(data, dict) else {}
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning("Could not parse existing %s: %s", output_path, e)
+        return {}
+
+
+def save_yaml(output_path: str, data: dict) -> None:
+    """Write the YAML document, ensuring the output directory exists."""
+    ensure_output_directory(output_path)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(
+            "# 上場廃止企業リスト (auto-generated)\n"
+            "# 検出方法: JPX data_j.xls にない、かつ stock_exchange_mapping.yml 未登録、\n"
+            "#           かつ data/jsons/ で過去に観測された secCode\n"
+            "# 自動更新スクリプト: bin/update_delisted_companies.py\n"
+        )
+        yaml.safe_dump(
+            data,
+            f,
+            allow_unicode=True,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+
+
+def write_step_summary(message: str) -> None:
+    """Append a message to $GITHUB_STEP_SUMMARY, if that env var is set."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    try:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write(message + "\n")
+    except OSError as e:
+        logger.warning("Could not write GitHub step summary: %s", e)
+
+
+def run(
+    jsons_dir: str,
+    mapping_path: str,
+    output_path: str,
+    max_consecutive_failures: int,
+    source_url: str,
+) -> int:
+    """
+    Execute the update. Returns the process exit code.
+    """
+    existing = load_existing_yaml(output_path)
+    today = today_iso()
+
+    # --- 1) Download JPX file ---
+    try:
+        xls_path = download_jpx_xls(source_url)
+    except Exception as e:  # noqa: BLE001
+        logger.error("JPX download failed: %s", e)
+        failed_doc, count = record_failure(existing, today)
+        save_yaml(output_path, failed_doc)
+
+        message = (
+            f":warning: delisted-companies update failed ({count} consecutive). "
+            f"Reason: {e}"
+        )
+        if count >= max_consecutive_failures:
+            logger.error(
+                "%d consecutive failures reached (threshold=%d). Failing step.",
+                count,
+                max_consecutive_failures,
+            )
+            write_step_summary(message + " **Failing the step.**")
+            return 1
+        if count >= 2:
+            logger.warning("%d consecutive failures. Writing GitHub step summary.", count)
+            write_step_summary(message)
+        else:
+            logger.warning("%d consecutive failure (soft warning).", count)
+        return 0
+
+    try:
+        # --- 2) Parse JPX listing ---
+        jpx_listed = load_jpx_listed_set(xls_path)
+
+        # --- 3) Build regional exclusion set ---
+        regional_skip = load_regional_skip_set(mapping_path)
+
+        # --- 4) Collect observed secCodes from daily JSONs ---
+        observed_map = load_observed_secs_from_jsons(jsons_dir)
+        observed_set = set(observed_map.keys())
+
+        # --- 5) Compute the current delisted set ---
+        current_delisted = compute_delisted(observed_set, jpx_listed, regional_skip)
+        logger.info(
+            "Detection stats: observed=%d, jpx_listed=%d, regional_skip=%d, delisted=%d",
+            len(observed_set),
+            len(jpx_listed),
+            len(regional_skip),
+            len(current_delisted),
+        )
+
+        # --- 6) Merge with existing yml (preserve detectedDate) ---
+        merged = merge_delisted_yaml(
+            existing=existing,
+            current_delisted=current_delisted,
+            company_names=observed_map,
+            today=today,
+            source_url=source_url,
+        )
+
+        # --- 7) Write ---
+        save_yaml(output_path, merged)
+        logger.info(
+            "Wrote %s: %d delisted entries",
+            output_path,
+            len(merged.get("delisted", {})),
+        )
+        return 0
+    finally:
+        try:
+            os.unlink(xls_path)
+        except OSError:
+            pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect delisted companies and update data/delisted_companies.yml",
+    )
+    parser.add_argument(
+        "--jsonsdir",
+        default="data/jsons",
+        help="Directory containing daily EDINET JSON files (default: data/jsons)",
+    )
+    parser.add_argument(
+        "--mapping",
+        default="config/stock_exchange_mapping.yml",
+        help="Regional exchange mapping YAML file (used as exclusion list)",
+    )
+    parser.add_argument(
+        "--output",
+        default="data/delisted_companies.yml",
+        help="Output YAML path (default: data/delisted_companies.yml)",
+    )
+    parser.add_argument(
+        "--source-url",
+        default=JPX_DATA_J_URL,
+        help="JPX data_j.xls URL (default: official JPX URL)",
+    )
+    parser.add_argument(
+        "--max-consecutive-failures",
+        type=int,
+        default=3,
+        help="Exit 1 after this many consecutive JPX fetch failures (default: 3)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable DEBUG logging",
+    )
+    args = parser.parse_args()
+
+    setup_logging("update_delisted_companies", args.verbose)
+
+    return run(
+        jsons_dir=args.jsonsdir,
+        mapping_path=args.mapping,
+        output_path=args.output,
+        max_consecutive_failures=args.max_consecutive_failures,
+        source_url=args.source_url,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/delisted_companies.yml
+++ b/data/delisted_companies.yml
@@ -1,0 +1,811 @@
+# 上場廃止企業リスト (auto-generated)
+# 検出方法: JPX data_j.xls にない、かつ stock_exchange_mapping.yml 未登録、
+#           かつ data/jsons/ で過去に観測された secCode
+# 自動更新スクリプト: bin/update_delisted_companies.py
+metadata:
+  schema_version: 1
+  last_updated: '2026-04-11'
+  last_success: '2026-04-11'
+  consecutive_failures: 0
+  source: https://www.jpx.co.jp/markets/statistics-equities/misc/tvdivq0000001vg2-att/data_j.xls
+delisted:
+  '1451':
+    name: 株式会社ＫＨＣ
+    detectedDate: '2026-04-11'
+    reason: null
+  165A:
+    name: ＳＢＩレオスひふみ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1712':
+    name: 株式会社ダイセキ環境ソリューション
+    detectedDate: '2026-04-11'
+    reason: null
+  '1730':
+    name: 麻生フオームクリート株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1743':
+    name: コーアツ工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1757':
+    name: 株式会社創建エース
+    detectedDate: '2026-04-11'
+    reason: null
+  176A:
+    name: レジル株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1775':
+    name: 富士古河Ｅ＆Ｃ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1805':
+    name: 飛島建設株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1821':
+    name: 三井住友建設株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1841':
+    name: サンユー建設株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1884':
+    name: 日本道路株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1890':
+    name: 東洋建設株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1949':
+    name: 住友電設株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '1973':
+    name: ＮＥＣネッツエスアイ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '2107':
+    name: 東洋精糖株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '2150':
+    name: 株式会社ケアネット
+    detectedDate: '2026-04-11'
+    reason: null
+  '2196':
+    name: 株式会社エスクリ
+    detectedDate: '2026-04-11'
+    reason: null
+  '2372':
+    name: 株式会社アイロムグループ
+    detectedDate: '2026-04-11'
+    reason: null
+  '2374':
+    name: セントケア・ホールディング株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '2389':
+    name: 株式会社デジタルホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '2397':
+    name: 株式会社ＤＮＡチップ研究所
+    detectedDate: '2026-04-11'
+    reason: null
+  '2468':
+    name: 株式会社フュートレック
+    detectedDate: '2026-04-11'
+    reason: null
+  '2599':
+    name: ジャパンフーズ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  260A:
+    name: 株式会社オルツ
+    detectedDate: '2026-04-11'
+    reason: null
+  '2715':
+    name: エレマテック株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '2743':
+    name: ピクセルカンパニーズ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '2754':
+    name: 株式会社東葛ホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '2830':
+    name: アヲハタ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '2899':
+    name: 株式会社永谷園ホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '3073':
+    name: 株式会社ＤＤグループ
+    detectedDate: '2026-04-11'
+    reason: null
+  '3094':
+    name: 株式会社スーパーバリュー
+    detectedDate: '2026-04-11'
+    reason: null
+  '3136':
+    name: 株式会社エコノス
+    detectedDate: '2026-04-11'
+    reason: null
+  '3141':
+    name: ウエルシアホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3254':
+    name: 株式会社プレサンスコーポレーション
+    detectedDate: '2026-04-11'
+    reason: null
+  '3264':
+    name: 株式会社アスコット
+    detectedDate: '2026-04-11'
+    reason: null
+  '3275':
+    name: ハウスコム株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3319':
+    name: 株式会社ゴルフダイジェスト・オンライン
+    detectedDate: '2026-04-11'
+    reason: null
+  '3322':
+    name: アルファグループ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3328':
+    name: ＢＥＥＮＯＳ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3341':
+    name: 日本調剤株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3347':
+    name: 株式会社トラスト
+    detectedDate: '2026-04-11'
+    reason: null
+  '3458':
+    name: 株式会社シーアールイー
+    detectedDate: '2026-04-11'
+    reason: null
+  '3497':
+    name: 株式会社ＬｅＴｅｃｈ
+    detectedDate: '2026-04-11'
+    reason: null
+  '3526':
+    name: 芦森工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3540':
+    name: 株式会社歯愛メディカル
+    detectedDate: '2026-04-11'
+    reason: null
+  '3604':
+    name: 川本産業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3655':
+    name: 株式会社ブレインパッド
+    detectedDate: '2026-04-11'
+    reason: null
+  '3666':
+    name: 株式会社テクノスジャパン
+    detectedDate: '2026-04-11'
+    reason: null
+  '3688':
+    name: 株式会社ＣＡＲＴＡ　ＨＯＬＤＩＮＧＳ
+    detectedDate: '2026-04-11'
+    reason: null
+  '3738':
+    name: 株式会社ティーガイア
+    detectedDate: '2026-04-11'
+    reason: null
+  '3770':
+    name: 株式会社ザッパラス
+    detectedDate: '2026-04-11'
+    reason: null
+  '3814':
+    name: 株式会社アルファクス・フード・システム
+    detectedDate: '2026-04-11'
+    reason: null
+  '3830':
+    name: 株式会社ギガプライズ
+    detectedDate: '2026-04-11'
+    reason: null
+  '3847':
+    name: パシフィックシステム株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3857':
+    name: 株式会社ラック
+    detectedDate: '2026-04-11'
+    reason: null
+  '3924':
+    name: 株式会社ランドコンピュータ
+    detectedDate: '2026-04-11'
+    reason: null
+  '3952':
+    name: 中央紙器工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3961':
+    name: シルバーエッグ・テクノロジー株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '3978':
+    name: 株式会社マクロミル
+    detectedDate: '2026-04-11'
+    reason: null
+  '3990':
+    name: ＵＵＵＭ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4080':
+    name: 株式会社田中化学研究所
+    detectedDate: '2026-04-11'
+    reason: null
+  '4173':
+    name: 株式会社ＷＡＣＵＬ
+    detectedDate: '2026-04-11'
+    reason: null
+  '4215':
+    name: タキロンシーアイ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4267':
+    name: 株式会社ライトワークス
+    detectedDate: '2026-04-11'
+    reason: null
+  '4268':
+    name: エッジテクノロジー株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4295':
+    name: 株式会社フェイス
+    detectedDate: '2026-04-11'
+    reason: null
+  '4298':
+    name: 株式会社プロトコーポレーション
+    detectedDate: '2026-04-11'
+    reason: null
+  '4304':
+    name: 株式会社Ｅストアー
+    detectedDate: '2026-04-11'
+    reason: null
+  '4319':
+    name: ＴＡＣ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4333':
+    name: 株式会社東邦システムサイエンス
+    detectedDate: '2026-04-11'
+    reason: null
+  '4348':
+    name: インフォコム株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4349':
+    name: 株式会社テスク
+    detectedDate: '2026-04-11'
+    reason: null
+  '4435':
+    name: 株式会社カオナビ
+    detectedDate: '2026-04-11'
+    reason: null
+  '4485':
+    name: 株式会社ＪＴＯＷＥＲ
+    detectedDate: '2026-04-11'
+    reason: null
+  '4551':
+    name: 鳥居薬品株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4726':
+    name: ＳＢテクノロジー株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4745':
+    name: 株式会社東京個別指導学院
+    detectedDate: '2026-04-11'
+    reason: null
+  '4770':
+    name: 図研エルミック株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4781':
+    name: 日本ハウズイング株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '4824':
+    name: 株式会社メディアシーク
+    detectedDate: '2026-04-11'
+    reason: null
+  '4921':
+    name: 株式会社ファンケル
+    detectedDate: '2026-04-11'
+    reason: null
+  '4957':
+    name: ヤスハラケミカル株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5009':
+    name: 富士興産株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5017':
+    name: 富士石油株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5070':
+    name: 株式会社ドラフト
+    detectedDate: '2026-04-11'
+    reason: null
+  '5191':
+    name: 住友理工株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5217':
+    name: テクノクオーツ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5277':
+    name: 株式会社スパンクリートコーポレーション
+    detectedDate: '2026-04-11'
+    reason: null
+  '5352':
+    name: 黒崎播磨株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5476':
+    name: 日本高周波鋼業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5481':
+    name: 山陽特殊製鋼株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5577':
+    name: 株式会社アイデミー
+    detectedDate: '2026-04-11'
+    reason: null
+  '5585':
+    name: エコナビスタ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5595':
+    name: 株式会社ＱＰＳ研究所
+    detectedDate: '2026-04-11'
+    reason: null
+  '5596':
+    name: アウトルックコンサルティング株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5759':
+    name: 日本電解株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5809':
+    name: タツタ電線株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5836':
+    name: 株式会社エージェント・インシュアランス・グループ
+    detectedDate: '2026-04-11'
+    reason: null
+  '5935':
+    name: 元旦ビューティ工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '5993':
+    name: 知多鋼業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6026':
+    name: ＧＭＯ　ＴＥＣＨ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6028':
+    name: テクノプロ・ホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6048':
+    name: 株式会社デザインワン・ジャパン
+    detectedDate: '2026-04-11'
+    reason: null
+  '6060':
+    name: こころネット株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6095':
+    name: メドピア株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6131':
+    name: 浜井産業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6210':
+    name: ＴＯＹＯイノベックス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6236':
+    name: ＮＣホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6293':
+    name: 日精樹脂工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6297':
+    name: 鉱研工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6312':
+    name: フロイント産業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6319':
+    name: 株式会社シンニッタン
+    detectedDate: '2026-04-11'
+    reason: null
+  '6362':
+    name: 株式会社石井鐵工所
+    detectedDate: '2026-04-11'
+    reason: null
+  '6373':
+    name: 大同工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6406':
+    name: フジテック株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6411':
+    name: 中野冷機株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6416':
+    name: 桂川電機株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6542':
+    name: 株式会社ＦＣホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '6550':
+    name: Ｕｎｉｐｏｓ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6698':
+    name: ヴィスコ・テクノロジーズ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6704':
+    name: 岩崎通信機株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6715':
+    name: 株式会社ナカヨ
+    detectedDate: '2026-04-11'
+    reason: null
+  '6734':
+    name: 株式会社ニューテック
+    detectedDate: '2026-04-11'
+    reason: null
+  '6755':
+    name: 株式会社富士通ゼネラル
+    detectedDate: '2026-04-11'
+    reason: null
+  '6879':
+    name: 株式会社ＩＭＡＧＩＣＡ　ＧＲＯＵＰ
+    detectedDate: '2026-04-11'
+    reason: null
+  '6930':
+    name: 日本アンテナ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6937':
+    name: 古河電池株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6957':
+    name: 株式会社芝浦電子
+    detectedDate: '2026-04-11'
+    reason: null
+  '6967':
+    name: 新光電気工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '6973':
+    name: 協栄産業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7086':
+    name: 株式会社きずなホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '7116':
+    name: ダイワ通信株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7163':
+    name: 住信ＳＢＩネット銀行株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7205':
+    name: 日野自動車株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7268':
+    name: 株式会社タツミ
+    detectedDate: '2026-04-11'
+    reason: null
+  '7379':
+    name: 株式会社サーキュレーション
+    detectedDate: '2026-04-11'
+    reason: null
+  '7386':
+    name: ジャパンワランティサポート株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7408':
+    name: 株式会社ジャムコ
+    detectedDate: '2026-04-11'
+    reason: null
+  '7420':
+    name: 佐鳥電機株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7445':
+    name: 株式会社ライトオン
+    detectedDate: '2026-04-11'
+    reason: null
+  '7451':
+    name: 三菱食品株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7455':
+    name: 株式会社パリミキホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '7467':
+    name: 萩原電気ホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7518':
+    name: ネットワンシステムズ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7533':
+    name: 株式会社グリーンクロス
+    detectedDate: '2026-04-11'
+    reason: null
+  '7559':
+    name: ジーエフシー株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7605':
+    name: 株式会社　フジ・コーポレーション
+    detectedDate: '2026-04-11'
+    reason: null
+  '7623':
+    name: 株式会社サンオータス
+    detectedDate: '2026-04-11'
+    reason: null
+  '7635':
+    name: 杉田エース株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7647':
+    name: 株式会社音通
+    detectedDate: '2026-04-11'
+    reason: null
+  '7705':
+    name: ジーエルサイエンス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7718':
+    name: スター精密株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7732':
+    name: 株式会社　トプコン
+    detectedDate: '2026-04-11'
+    reason: null
+  '7817':
+    name: パラマウントベッドホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7829':
+    name: 株式会社サマンサタバサジャパンリミテッド
+    detectedDate: '2026-04-11'
+    reason: null
+  '7923':
+    name: トーイン株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '7958':
+    name: 天馬株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8038':
+    name: 東都水産株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8072':
+    name: 日本出版貿易株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8114':
+    name: 株式会社デサント
+    detectedDate: '2026-04-11'
+    reason: null
+  '8155':
+    name: 三益半導体工業株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8182':
+    name: 株式会社いなげや
+    detectedDate: '2026-04-11'
+    reason: null
+  '8208':
+    name: 株式会社エンチョー
+    detectedDate: '2026-04-11'
+    reason: null
+  '8215':
+    name: 株式会社銀座山形屋
+    detectedDate: '2026-04-11'
+    reason: null
+  '8279':
+    name: 株式会社ヤオコー
+    detectedDate: '2026-04-11'
+    reason: null
+  '8462':
+    name: フューチャーベンチャーキャピタル株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8515':
+    name: アイフル株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8732':
+    name: 株式会社マネーパートナーズグループ
+    detectedDate: '2026-04-11'
+    reason: null
+  '8886':
+    name: 株式会社ウッドフレンズ
+    detectedDate: '2026-04-11'
+    reason: null
+  '8890':
+    name: 株式会社レーサム
+    detectedDate: '2026-04-11'
+    reason: null
+  '8905':
+    name: イオンモール株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '8940':
+    name: 株式会社インテリックス
+    detectedDate: '2026-04-11'
+    reason: null
+  '9055':
+    name: 株式会社アルプス物流
+    detectedDate: '2026-04-11'
+    reason: null
+  '9058':
+    name: トランコム株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9066':
+    name: 株式会社日新
+    detectedDate: '2026-04-11'
+    reason: null
+  '9070':
+    name: トナミホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9078':
+    name: 株式会社エスライングループ本社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9099':
+    name: 株式会社Ｃ＆Ｆロジホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '9161':
+    name: ＩＤ＆Ｅホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9164':
+    name: 株式会社トライト
+    detectedDate: '2026-04-11'
+    reason: null
+  '9232':
+    name: 株式会社パスコ
+    detectedDate: '2026-04-11'
+    reason: null
+  '9260':
+    name: 西本Ｗｉｓｍｅｔｔａｃホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9275':
+    name: 株式会社ナルミヤ・インターナショナル
+    detectedDate: '2026-04-11'
+    reason: null
+  '9377':
+    name: 株式会社　エージーピー
+    detectedDate: '2026-04-11'
+    reason: null
+  '9384':
+    name: 内外トランスライン株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9386':
+    name: 日本コンセプト株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9479':
+    name: 株式会社インプレスホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '9600':
+    name: 株式会社アイネット
+    detectedDate: '2026-04-11'
+    reason: null
+  '9613':
+    name: 株式会社ＮＴＴデータグループ
+    detectedDate: '2026-04-11'
+    reason: null
+  '9675':
+    name: 常磐興産株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9696':
+    name: 株式会社ウィザス
+    detectedDate: '2026-04-11'
+    reason: null
+  '9719':
+    name: ＳＣＳＫ株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9749':
+    name: 富士ソフト株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9776':
+    name: 札幌臨床検査センター株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9783':
+    name: 株式会社ベネッセホールディングス
+    detectedDate: '2026-04-11'
+    reason: null
+  '9787':
+    name: イオンディライト株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9852':
+    name: ＣＢグループマネジメント株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9873':
+    name: 日本ＫＦＣホールディングス株式会社
+    detectedDate: '2026-04-11'
+    reason: null
+  '9919':
+    name: 株式会社関西フードマーケット
+    detectedDate: '2026-04-11'
+    reason: null

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,6 +107,14 @@
             <p class="loading-text">データを読み込んでいます...</p>
         </div>
 
+        <!-- Legend -->
+        <div class="legend-container" aria-label="凡例">
+            <span class="legend-chip">
+                <span class="badge badge-delisted">廃止</span>
+                上場廃止企業
+            </span>
+        </div>
+
         <!-- Data Table -->
         <div id="table-container" style="display: none;">
             <table id="data-table" role="table" aria-label="財務データ一覧">

--- a/docs/script.js
+++ b/docs/script.js
@@ -608,9 +608,19 @@ function displayData(data) {
             row.style.animationDelay = '300ms';
         }
 
+        // Mark delisted companies for visual styling and screen readers.
+        if (item.isDelisted) {
+            row.classList.add('delisted-row');
+            row.setAttribute('aria-label', `上場廃止（検知日: ${item.delistedDate || '不明'}）`);
+        }
+
+        const delistedBadge = item.isDelisted
+            ? ` <span class="badge badge-delisted" title="上場廃止（検知日: ${escapeHtml(item.delistedDate || '不明')}）">廃止</span>`
+            : '';
+
         row.innerHTML = `
             <td class="sec-code sticky-col sticky-col-1">${item.yahooURL ? `<a href="${encodeURI(item.yahooURL)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.secCode)}</a>` : escapeHtml(item.secCode) || '-'}</td>
-            <td class="company-name sticky-col sticky-col-2">${item.docPdfURL ? `<a href="${encodeURI(item.docPdfURL)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.filerName)}</a>` : escapeHtml(item.filerName) || '-'}</td>
+            <td class="company-name sticky-col sticky-col-2">${item.docPdfURL ? `<a href="${encodeURI(item.docPdfURL)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.filerName)}</a>` : escapeHtml(item.filerName) || '-'}${delistedBadge}</td>
             <td>${escapeHtml(item.periodEnd) || '-'}</td>
             <td class="number-cell">${formatStockPrice(item.stockPrice)}</td>
             <td class="number-cell">${formatNumber(item.netSales)}</td>
@@ -865,7 +875,9 @@ function exportToExcel() {
         '純資産合計(百万円)': item.equity ? Math.round(item.equity / MILLION) : '',
         'ネット有利子負債(百万円)': item.debt ? Math.round(item.debt / MILLION) : '',
         'EDINET提出日': item.issuedDate || '',
-        '最終更新日': item.retrievedDate || ''
+        '最終更新日': item.retrievedDate || '',
+        '上場廃止': item.isDelisted ? 'TRUE' : 'FALSE',
+        '上場廃止検知日': item.delistedDate || ''
     }));
 
     const ws = XLSX.utils.json_to_sheet(exportData);
@@ -875,7 +887,7 @@ function exportToExcel() {
         {wch: 15}, {wch: 15}, {wch: 15}, {wch: 15}, {wch: 12},
         {wch: 15}, {wch: 12}, {wch: 15}, {wch: 15}, {wch: 15},
         {wch: 10}, {wch: 15}, {wch: 12}, {wch: 10}, {wch: 15},
-        {wch: 20}, {wch: 12}, {wch: 12}
+        {wch: 20}, {wch: 12}, {wch: 12}, {wch: 10}, {wch: 15}
     ];
 
     const wb = XLSX.utils.book_new();

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -611,6 +611,75 @@ td {
     vertical-align: middle;
 }
 
+/* Delisted Row (上場廃止) */
+tbody tr.delisted-row td {
+    color: var(--text-muted);
+    background: color-mix(in srgb, var(--surface-tertiary) 60%, var(--negative-subtle));
+}
+
+tbody tr.delisted-row .sticky-col {
+    background: color-mix(in srgb, var(--sticky-bg) 85%, var(--negative-subtle));
+}
+
+tbody tr.delisted-row:hover td {
+    background: color-mix(in srgb, var(--row-hover) 50%, var(--negative-subtle));
+}
+
+tbody tr.delisted-row .company-name,
+tbody tr.delisted-row .sec-code {
+    color: var(--text-tertiary);
+}
+
+tbody tr.delisted-row .number-cell {
+    text-decoration: line-through;
+    text-decoration-color: var(--text-muted);
+}
+
+/* "廃止" Badge */
+.badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: 6px;
+    vertical-align: middle;
+    letter-spacing: 0.02em;
+    line-height: 1.4;
+}
+
+.badge-delisted {
+    background: var(--negative-subtle);
+    color: var(--negative);
+    border: 1px solid color-mix(in srgb, var(--negative) 30%, transparent);
+}
+
+/* Legend container */
+.legend-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 8px 24px 0;
+    justify-content: flex-end;
+}
+
+/* Legend chip (header) */
+.legend-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+    padding: 4px 10px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-tertiary);
+    border: 1px solid var(--border-subtle);
+}
+
+.legend-chip .badge-delisted {
+    margin-left: 0;
+}
+
 /* Highlight Row (Search Result) */
 tbody tr.highlight {
     animation: highlightPulse 2s ease-out;

--- a/lib/delisted_detector.py
+++ b/lib/delisted_detector.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Delisted Company Detector
+
+Utilities for detecting delisted Japanese listed companies by comparing
+the set of securities codes observed in EDINET daily fetches against the
+JPX "東証上場銘柄一覧" (data_j.xls) snapshot.
+
+The detection policy is:
+    delisted = (observed_secs - regional_skip) - jpx_listed
+
+where:
+    observed_secs : secCodes ever seen in data/jsons/*.json (past EDINET data)
+    jpx_listed    : secCodes currently present in JPX data_j.xls
+    regional_skip : secCodes registered in config/stock_exchange_mapping.yml
+                    (Nagoya / Fukuoka / Sapporo single-listed stocks which
+                    are NOT included in the JPX Tokyo snapshot and must be
+                    excluded to avoid false positives).
+"""
+
+import glob
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Dict, Optional, Set, Tuple
+
+import xlrd
+import yaml
+
+# Allow running as a script from the project root or from lib/.
+try:
+    from lib.edinet_common import normalize_securities_code
+except ImportError:  # pragma: no cover - fallback when lib is on sys.path directly
+    from edinet_common import normalize_securities_code
+
+logger = logging.getLogger(__name__)
+
+JPX_DATA_J_URL = (
+    "https://www.jpx.co.jp/markets/statistics-equities/misc/"
+    "tvdivq0000001vg2-att/data_j.xls"
+)
+
+# Candidate header names for the JPX "code" column.
+_JPX_CODE_COLUMNS = ("コード", "Local Code", "コード（Code）")
+
+
+def _normalize_raw_code(raw) -> str:
+    """
+    Convert a raw cell value (from xlrd or similar) into a securities code
+    string. xlrd returns numeric-looking codes as floats (e.g., 1301.0), so
+    we convert them to zero-padded 4-digit strings. Alphanumeric codes
+    (e.g., 259A) are returned as plain strings.
+    """
+    if raw is None:
+        return ""
+    if isinstance(raw, float):
+        if raw != raw:  # NaN
+            return ""
+        return str(int(raw)).zfill(4)
+    if isinstance(raw, int):
+        return str(raw).zfill(4)
+    return str(raw).strip()
+
+
+def load_jpx_listed_set(xls_path: str) -> Set[str]:
+    """
+    Load the set of currently-listed securities codes from the JPX snapshot.
+
+    Uses xlrd directly (not pandas) because pandas 2.x requires xlrd>=2.0,
+    but xlrd 2.x dropped .xls support. The `data_j.xls` file JPX publishes
+    is an actual legacy .xls, so we pin xlrd==1.2.0 and call it directly.
+
+    Args:
+        xls_path: Local path to the downloaded data_j.xls file.
+
+    Returns:
+        Set of normalized securities codes currently listed on JPX (TSE).
+
+    Raises:
+        FileNotFoundError: If xls_path does not exist.
+        ValueError: If the code column cannot be located in the sheet.
+    """
+    if not os.path.exists(xls_path):
+        raise FileNotFoundError(f"JPX listing file not found: {xls_path}")
+
+    book = xlrd.open_workbook(xls_path)
+    sheet = book.sheet_by_index(0)
+
+    if sheet.nrows < 1:
+        raise ValueError(f"JPX sheet is empty: {xls_path}")
+
+    header = [sheet.cell_value(0, c) for c in range(sheet.ncols)]
+    code_col_idx = None
+    for idx, name in enumerate(header):
+        if name in _JPX_CODE_COLUMNS:
+            code_col_idx = idx
+            break
+
+    if code_col_idx is None:
+        raise ValueError(
+            f"Could not find a securities code column in {xls_path}. "
+            f"Columns present: {header}"
+        )
+
+    listed: Set[str] = set()
+    for row_idx in range(1, sheet.nrows):
+        raw = sheet.cell_value(row_idx, code_col_idx)
+        code = _normalize_raw_code(raw)
+        if not code:
+            continue
+        listed.add(normalize_securities_code(code))
+
+    logger.info(
+        "Loaded %d listed securities codes from JPX snapshot: %s",
+        len(listed),
+        xls_path,
+    )
+    return listed
+
+
+def load_regional_skip_set(config_path: str) -> Set[str]:
+    """
+    Load the exclusion set from config/stock_exchange_mapping.yml.
+
+    Codes registered in this file denote regional-exchange single-listed stocks
+    (Nagoya / Fukuoka / Sapporo) that are NOT represented in JPX data_j.xls.
+    They must be skipped during delisted detection to avoid being flagged as
+    delisted.
+
+    Args:
+        config_path: Path to config/stock_exchange_mapping.yml
+
+    Returns:
+        Set of securities codes to exclude from delisted judgement.
+        Returns an empty set if the file is missing or unreadable.
+    """
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning("Could not load regional skip mapping %s: %s", config_path, e)
+        return set()
+
+    mapping = data.get("stock_exchanges", {}) or {}
+    return {str(code) for code in mapping.keys()}
+
+
+def load_observed_secs_from_jsons(jsons_dir: str) -> Dict[str, str]:
+    """
+    Scan data/jsons/*.json files to collect every secCode ever observed and
+    the most recently seen company name for that code.
+
+    Recency is determined by the daily JSON filename (YYYY-MM-DD.json).
+    Files whose names do not match that format are still processed but their
+    entries never "win" the recency comparison.
+
+    Args:
+        jsons_dir: Directory containing daily JSON files.
+
+    Returns:
+        Mapping of {secCode: filerName} based on the most recently observed
+        occurrence of each code.
+    """
+    observed: Dict[str, Tuple[str, str]] = {}
+
+    pattern = os.path.join(jsons_dir, "*.json")
+    json_files = sorted(glob.glob(pattern))
+
+    for json_file in json_files:
+        filename = os.path.basename(json_file)
+        date_str = filename[:-5] if filename.endswith(".json") else ""
+
+        try:
+            with open(json_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Could not read %s: %s", json_file, e)
+            continue
+
+        if not isinstance(data, list):
+            continue
+
+        for company in data:
+            if not isinstance(company, dict):
+                continue
+            raw_code = company.get("secCode")
+            if not raw_code:
+                continue
+            sec_code = normalize_securities_code(str(raw_code))
+            if not sec_code:
+                continue
+            name = company.get("filerName") or ""
+            previous = observed.get(sec_code)
+            if previous is None or date_str > previous[0]:
+                observed[sec_code] = (date_str, name)
+
+    logger.info(
+        "Observed %d distinct securities codes across %d JSON files",
+        len(observed),
+        len(json_files),
+    )
+    return {code: name for code, (_date, name) in observed.items()}
+
+
+def compute_delisted(
+    observed_secs: Set[str],
+    jpx_listed: Set[str],
+    regional_skip: Set[str],
+) -> Set[str]:
+    """
+    Compute the set of currently-delisted securities codes.
+
+        delisted = (observed_secs - regional_skip) - jpx_listed
+
+    Args:
+        observed_secs: All secCodes ever observed in EDINET daily fetches.
+        jpx_listed:    secCodes currently listed on JPX (from data_j.xls).
+        regional_skip: secCodes to exclude (regional single-listed stocks).
+
+    Returns:
+        Set of secCodes considered delisted.
+    """
+    candidates = observed_secs - regional_skip
+    return candidates - jpx_listed
+
+
+def merge_delisted_yaml(
+    existing: Optional[dict],
+    current_delisted: Set[str],
+    company_names: Dict[str, str],
+    today: str,
+    source_url: str = JPX_DATA_J_URL,
+) -> dict:
+    """
+    Merge a freshly computed delisted set into the existing YAML structure,
+    preserving ``detectedDate`` of codes that were already known to be
+    delisted, removing codes that have returned to the JPX listing, and
+    refreshing metadata.
+
+    Args:
+        existing: Previous delisted_companies.yml content (may be None/empty).
+        current_delisted: Full set of currently-delisted secCodes.
+        company_names: Mapping {secCode: filerName} for naming new entries.
+        today: Today's date in YYYY-MM-DD format. Used as ``detectedDate``
+               for newly discovered codes and as ``last_updated`` /
+               ``last_success`` in metadata.
+        source_url: Source attribution stored in metadata.
+
+    Returns:
+        A new dict ready to be dumped to YAML with the shape::
+
+            metadata:
+              schema_version: 1
+              last_updated: "YYYY-MM-DD"
+              last_success: "YYYY-MM-DD"
+              consecutive_failures: 0
+              source: "https://..."
+            delisted:
+              "1234":
+                name: "..."
+                detectedDate: "YYYY-MM-DD"
+                reason: null
+    """
+    existing = existing or {}
+    existing_meta = (existing.get("metadata") or {}) if isinstance(existing, dict) else {}
+    existing_delisted = (existing.get("delisted") or {}) if isinstance(existing, dict) else {}
+
+    merged: Dict[str, dict] = {}
+
+    # Retain entries that are still delisted; drop the ones that were reinstated.
+    for code, info in existing_delisted.items():
+        code_str = str(code)
+        if code_str not in current_delisted:
+            logger.info("Reinstated (reappeared in JPX listing): %s", code_str)
+            continue
+        entry = dict(info) if isinstance(info, dict) else {}
+        # Refresh the display name if we have a newer observation.
+        new_name = company_names.get(code_str)
+        if new_name:
+            entry["name"] = new_name
+        entry.setdefault("detectedDate", today)
+        entry.setdefault("reason", None)
+        merged[code_str] = entry
+
+    # Add newly detected codes.
+    for code in sorted(current_delisted):
+        if code in merged:
+            continue
+        logger.info("Newly detected delisted: %s (%s)", code, company_names.get(code, ""))
+        merged[code] = {
+            "name": company_names.get(code, ""),
+            "detectedDate": today,
+            "reason": None,
+        }
+
+    result = {
+        "metadata": {
+            "schema_version": 1,
+            "last_updated": today,
+            "last_success": today,
+            "consecutive_failures": 0,
+            "source": existing_meta.get("source") or source_url,
+        },
+        "delisted": dict(sorted(merged.items())),
+    }
+    return result
+
+
+def record_failure(existing: Optional[dict], today: str) -> Tuple[dict, int]:
+    """
+    Build a YAML dict reflecting a failed JPX fetch.
+
+    Increments ``metadata.consecutive_failures``, updates ``last_updated``,
+    and preserves the existing ``delisted`` map intact. ``last_success`` is
+    preserved from the previous run.
+
+    Returns:
+        (new_yaml_dict, new_consecutive_failures_count)
+    """
+    existing = existing or {}
+    existing_meta = (existing.get("metadata") or {}) if isinstance(existing, dict) else {}
+    existing_delisted = (existing.get("delisted") or {}) if isinstance(existing, dict) else {}
+
+    prev_failures = int(existing_meta.get("consecutive_failures") or 0)
+    new_failures = prev_failures + 1
+
+    result = {
+        "metadata": {
+            "schema_version": 1,
+            "last_updated": today,
+            "last_success": existing_meta.get("last_success"),
+            "consecutive_failures": new_failures,
+            "source": existing_meta.get("source") or JPX_DATA_J_URL,
+        },
+        "delisted": dict(sorted((str(k), v) for k, v in existing_delisted.items())),
+    }
+    return result, new_failures
+
+
+def today_iso() -> str:
+    """Return today's date in YYYY-MM-DD format (local time)."""
+    return datetime.now().strftime("%Y-%m-%d")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "urllib3<2.0",
     "PyYAML>=6.0",
     "playwright>=1.40.0",
+    "xlrd==1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas>=2.0.0
 urllib3<2.0
 PyYAML>=6.0
 playwright>=1.40.0
+xlrd==1.2.0

--- a/tests/test_consolidate_delisted.py
+++ b/tests/test_consolidate_delisted.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Tests for the delisted-company annotation added to consolidate_documents.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Add parent directory to path so `bin.*` imports resolve.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from bin.consolidate_documents import DataConsolidator, load_delisted_map  # noqa: E402
+
+
+class TestLoadDelistedMap(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="edinet_consolidate_test_")
+        self.yaml_path = os.path.join(self.tmpdir, "delisted.yml")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, content: str):
+        with open(self.yaml_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    def test_empty_when_missing(self):
+        self.assertEqual(load_delisted_map("/nonexistent/delisted.yml"), {})
+
+    def test_loads_delisted_map(self):
+        self._write(
+            """metadata:
+  schema_version: 1
+delisted:
+  "1234":
+    name: テスト株式会社
+    detectedDate: "2026-02-14"
+    reason: null
+  "5678":
+    name: ABC
+    detectedDate: "2026-03-01"
+    reason: null
+"""
+        )
+        result = load_delisted_map(self.yaml_path)
+        self.assertIn("1234", result)
+        self.assertEqual(result["1234"]["detectedDate"], "2026-02-14")
+        self.assertIn("5678", result)
+
+    def test_empty_delisted_key(self):
+        self._write("metadata:\n  schema_version: 1\ndelisted: {}\n")
+        self.assertEqual(load_delisted_map(self.yaml_path), {})
+
+    def test_malformed_yaml(self):
+        self._write("not: valid: [yaml")
+        self.assertEqual(load_delisted_map(self.yaml_path), {})
+
+
+class TestAnnotateDelisted(unittest.TestCase):
+    """Verify _annotate_delisted attaches the right fields via consolidate_files()."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="edinet_consolidate_test_")
+        self.jsons_dir = os.path.join(self.tmpdir, "jsons")
+        os.makedirs(self.jsons_dir)
+        self.yaml_path = os.path.join(self.tmpdir, "delisted.yml")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_json(self, filename: str, companies):
+        path = os.path.join(self.jsons_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(companies, f, ensure_ascii=False)
+
+    def _write_yaml(self, body: str):
+        with open(self.yaml_path, "w", encoding="utf-8") as f:
+            f.write(body)
+
+    def test_flags_delisted_company(self):
+        from datetime import datetime
+
+        today = datetime.now().strftime("%Y-%m-%d")
+        self._write_json(
+            f"{today}.json",
+            [
+                {"secCode": "1234", "filerName": "Old Corp", "issuedDate": today},
+                {"secCode": "5678", "filerName": "Active Corp", "issuedDate": today},
+            ],
+        )
+        self._write_yaml(
+            """metadata:
+  schema_version: 1
+delisted:
+  "1234":
+    name: Old Corp
+    detectedDate: "2026-02-14"
+    reason: null
+"""
+        )
+
+        consolidator = DataConsolidator(self.jsons_dir, delisted_yaml_path=self.yaml_path)
+        results = consolidator.consolidate_files()
+
+        by_code = {c["secCode"]: c for c in results}
+        self.assertTrue(by_code["1234"]["isDelisted"])
+        self.assertEqual(by_code["1234"]["delistedDate"], "2026-02-14")
+        self.assertFalse(by_code["5678"]["isDelisted"])
+        self.assertIsNone(by_code["5678"]["delistedDate"])
+
+    def test_no_yaml_path_skips_annotation(self):
+        """When delisted_yaml_path is None, consolidate should not touch isDelisted."""
+        from datetime import datetime
+
+        today = datetime.now().strftime("%Y-%m-%d")
+        self._write_json(
+            f"{today}.json",
+            [{"secCode": "1234", "filerName": "Corp", "issuedDate": today}],
+        )
+
+        consolidator = DataConsolidator(self.jsons_dir, delisted_yaml_path=None)
+        results = consolidator.consolidate_files()
+
+        self.assertNotIn("isDelisted", results[0])
+        self.assertNotIn("delistedDate", results[0])
+
+    def test_missing_yaml_file_defaults_to_false(self):
+        from datetime import datetime
+
+        today = datetime.now().strftime("%Y-%m-%d")
+        self._write_json(
+            f"{today}.json",
+            [{"secCode": "1234", "filerName": "Corp", "issuedDate": today}],
+        )
+
+        missing_yaml = os.path.join(self.tmpdir, "nonexistent.yml")
+        consolidator = DataConsolidator(self.jsons_dir, delisted_yaml_path=missing_yaml)
+        results = consolidator.consolidate_files()
+
+        self.assertFalse(results[0]["isDelisted"])
+        self.assertIsNone(results[0]["delistedDate"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_delisted_detector.py
+++ b/tests/test_delisted_detector.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Tests for lib/delisted_detector.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add parent directory to path so `lib.*` imports resolve.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from lib import delisted_detector  # noqa: E402
+
+
+class TestComputeDelisted(unittest.TestCase):
+    """compute_delisted() set arithmetic"""
+
+    def test_basic_diff(self):
+        observed = {"1000", "2000", "3000", "4000"}
+        jpx_listed = {"1000", "2000", "9999"}
+        regional = set()
+        self.assertEqual(
+            delisted_detector.compute_delisted(observed, jpx_listed, regional),
+            {"3000", "4000"},
+        )
+
+    def test_regional_is_excluded(self):
+        # "3000" is observed and missing from JPX, but appears in regional skip.
+        # It should NOT be flagged as delisted.
+        observed = {"1000", "2000", "3000"}
+        jpx_listed = {"1000"}
+        regional = {"3000"}
+        self.assertEqual(
+            delisted_detector.compute_delisted(observed, jpx_listed, regional),
+            {"2000"},
+        )
+
+    def test_all_listed(self):
+        observed = {"1000", "2000"}
+        jpx_listed = {"1000", "2000", "3000"}
+        self.assertEqual(
+            delisted_detector.compute_delisted(observed, jpx_listed, set()),
+            set(),
+        )
+
+    def test_empty_observed(self):
+        self.assertEqual(
+            delisted_detector.compute_delisted(set(), {"1000"}, set()),
+            set(),
+        )
+
+    def test_alphanumeric_code(self):
+        observed = {"259A", "275A", "1000"}
+        jpx_listed = {"1000", "275A"}
+        self.assertEqual(
+            delisted_detector.compute_delisted(observed, jpx_listed, set()),
+            {"259A"},
+        )
+
+
+class TestMergeDelistedYaml(unittest.TestCase):
+    """merge_delisted_yaml() persistence logic"""
+
+    def test_new_entry_gets_today_date(self):
+        result = delisted_detector.merge_delisted_yaml(
+            existing=None,
+            current_delisted={"1234"},
+            company_names={"1234": "株式会社テスト"},
+            today="2026-04-11",
+        )
+        self.assertEqual(result["metadata"]["last_updated"], "2026-04-11")
+        self.assertEqual(result["metadata"]["last_success"], "2026-04-11")
+        self.assertEqual(result["metadata"]["consecutive_failures"], 0)
+        self.assertIn("1234", result["delisted"])
+        self.assertEqual(result["delisted"]["1234"]["name"], "株式会社テスト")
+        self.assertEqual(result["delisted"]["1234"]["detectedDate"], "2026-04-11")
+        self.assertIsNone(result["delisted"]["1234"]["reason"])
+
+    def test_existing_entry_preserves_detected_date(self):
+        existing = {
+            "metadata": {
+                "schema_version": 1,
+                "last_updated": "2026-02-01",
+                "last_success": "2026-02-01",
+                "consecutive_failures": 0,
+                "source": "https://example.com/data_j.xls",
+            },
+            "delisted": {
+                "1234": {
+                    "name": "旧名称",
+                    "detectedDate": "2025-12-01",
+                    "reason": None,
+                }
+            },
+        }
+        result = delisted_detector.merge_delisted_yaml(
+            existing=existing,
+            current_delisted={"1234"},
+            company_names={"1234": "新名称"},
+            today="2026-04-11",
+        )
+        self.assertEqual(result["delisted"]["1234"]["detectedDate"], "2025-12-01")
+        # Name is refreshed, detectedDate is preserved.
+        self.assertEqual(result["delisted"]["1234"]["name"], "新名称")
+
+    def test_reinstated_entry_is_removed(self):
+        existing = {
+            "metadata": {},
+            "delisted": {
+                "1234": {"name": "A", "detectedDate": "2025-12-01", "reason": None},
+                "5678": {"name": "B", "detectedDate": "2026-01-15", "reason": None},
+            },
+        }
+        # "1234" is still delisted; "5678" has reappeared in JPX listing.
+        result = delisted_detector.merge_delisted_yaml(
+            existing=existing,
+            current_delisted={"1234"},
+            company_names={"1234": "A", "5678": "B"},
+            today="2026-04-11",
+        )
+        self.assertIn("1234", result["delisted"])
+        self.assertNotIn("5678", result["delisted"])
+
+    def test_source_url_preserved_from_existing(self):
+        existing = {"metadata": {"source": "https://custom.example/data.xls"}, "delisted": {}}
+        result = delisted_detector.merge_delisted_yaml(
+            existing=existing,
+            current_delisted=set(),
+            company_names={},
+            today="2026-04-11",
+        )
+        self.assertEqual(result["metadata"]["source"], "https://custom.example/data.xls")
+
+    def test_default_source_url_when_missing(self):
+        result = delisted_detector.merge_delisted_yaml(
+            existing=None,
+            current_delisted=set(),
+            company_names={},
+            today="2026-04-11",
+        )
+        self.assertEqual(
+            result["metadata"]["source"],
+            delisted_detector.JPX_DATA_J_URL,
+        )
+
+    def test_consecutive_failures_reset_on_success(self):
+        existing = {"metadata": {"consecutive_failures": 2}, "delisted": {}}
+        result = delisted_detector.merge_delisted_yaml(
+            existing=existing,
+            current_delisted=set(),
+            company_names={},
+            today="2026-04-11",
+        )
+        self.assertEqual(result["metadata"]["consecutive_failures"], 0)
+
+
+class TestRecordFailure(unittest.TestCase):
+    """record_failure() increments counter and preserves delisted map"""
+
+    def test_increments_counter_from_zero(self):
+        existing = {"metadata": {"consecutive_failures": 0, "last_success": "2026-04-10"},
+                    "delisted": {"1234": {"name": "A", "detectedDate": "2025-12-01", "reason": None}}}
+        result, count = delisted_detector.record_failure(existing, "2026-04-11")
+        self.assertEqual(count, 1)
+        self.assertEqual(result["metadata"]["consecutive_failures"], 1)
+        self.assertEqual(result["metadata"]["last_updated"], "2026-04-11")
+        # last_success should be preserved.
+        self.assertEqual(result["metadata"]["last_success"], "2026-04-10")
+        # Delisted map preserved intact.
+        self.assertIn("1234", result["delisted"])
+
+    def test_increments_counter_from_two(self):
+        existing = {"metadata": {"consecutive_failures": 2}, "delisted": {}}
+        _, count = delisted_detector.record_failure(existing, "2026-04-11")
+        self.assertEqual(count, 3)
+
+    def test_missing_existing_starts_at_one(self):
+        result, count = delisted_detector.record_failure(None, "2026-04-11")
+        self.assertEqual(count, 1)
+        self.assertEqual(result["metadata"]["consecutive_failures"], 1)
+
+
+class TestLoadObservedSecsFromJsons(unittest.TestCase):
+    """load_observed_secs_from_jsons() scanning logic"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="edinet_test_")
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write_json(self, filename: str, data):
+        path = os.path.join(self.tmpdir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
+
+    def test_collects_all_observed_codes(self):
+        self._write_json("2026-01-01.json", [
+            {"secCode": "1000", "filerName": "Alpha"},
+            {"secCode": "2000", "filerName": "Beta"},
+        ])
+        self._write_json("2026-02-01.json", [
+            {"secCode": "3000", "filerName": "Gamma"},
+        ])
+        result = delisted_detector.load_observed_secs_from_jsons(self.tmpdir)
+        self.assertEqual(set(result.keys()), {"1000", "2000", "3000"})
+
+    def test_uses_most_recent_name(self):
+        self._write_json("2026-01-01.json", [{"secCode": "1000", "filerName": "旧名"}])
+        self._write_json("2026-03-01.json", [{"secCode": "1000", "filerName": "新名"}])
+        result = delisted_detector.load_observed_secs_from_jsons(self.tmpdir)
+        self.assertEqual(result["1000"], "新名")
+
+    def test_ignores_non_list_json(self):
+        self._write_json("2026-01-01.json", {"not": "a list"})
+        self._write_json("2026-02-01.json", [{"secCode": "1000", "filerName": "OK"}])
+        result = delisted_detector.load_observed_secs_from_jsons(self.tmpdir)
+        self.assertEqual(set(result.keys()), {"1000"})
+
+    def test_skips_entries_without_seccode(self):
+        self._write_json("2026-01-01.json", [
+            {"secCode": "1000", "filerName": "A"},
+            {"filerName": "no code"},
+            {"secCode": "", "filerName": "empty"},
+        ])
+        result = delisted_detector.load_observed_secs_from_jsons(self.tmpdir)
+        self.assertEqual(set(result.keys()), {"1000"})
+
+    def test_handles_malformed_json_gracefully(self):
+        path = os.path.join(self.tmpdir, "2026-04-01.json")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("{ not valid json")
+        self._write_json("2026-04-02.json", [{"secCode": "1000", "filerName": "OK"}])
+        result = delisted_detector.load_observed_secs_from_jsons(self.tmpdir)
+        self.assertEqual(set(result.keys()), {"1000"})
+
+
+def _make_fake_sheet(rows):
+    """Build a mock xlrd sheet from a 2D Python list."""
+    sheet = MagicMock()
+    sheet.nrows = len(rows)
+    sheet.ncols = len(rows[0]) if rows else 0
+
+    def cell_value(r, c):
+        return rows[r][c]
+
+    sheet.cell_value.side_effect = cell_value
+    return sheet
+
+
+class TestLoadJpxListedSet(unittest.TestCase):
+    """load_jpx_listed_set() handles xlrd cell types correctly"""
+
+    def setUp(self):
+        # Create a dummy file so os.path.exists passes.
+        self.tmpfile = tempfile.NamedTemporaryFile(suffix=".xls", delete=False)
+        self.tmpfile.write(b"fake")
+        self.tmpfile.close()
+
+    def tearDown(self):
+        os.unlink(self.tmpfile.name)
+
+    def _run_with_rows(self, rows):
+        sheet = _make_fake_sheet(rows)
+        book = MagicMock()
+        book.sheet_by_index.return_value = sheet
+        with patch.object(delisted_detector.xlrd, "open_workbook", return_value=book):
+            return delisted_detector.load_jpx_listed_set(self.tmpfile.name)
+
+    def test_float_codes_zero_padded(self):
+        rows = [
+            ["日付", "コード", "銘柄名"],
+            [20260401.0, 1301.0, "極洋"],
+            [20260401.0, 7203.0, "トヨタ自動車"],
+            [20260401.0, 9984.0, "ソフトバンクグループ"],
+        ]
+        result = self._run_with_rows(rows)
+        self.assertEqual(result, {"1301", "7203", "9984"})
+
+    def test_alphanumeric_codes_preserved(self):
+        rows = [
+            ["日付", "コード", "銘柄名"],
+            [20260401.0, "259A", "Alpha Corp"],
+            [20260401.0, 7203.0, "Toyota"],
+        ]
+        result = self._run_with_rows(rows)
+        self.assertEqual(result, {"259A", "7203"})
+
+    def test_empty_cells_are_skipped(self):
+        rows = [
+            ["日付", "コード", "銘柄名"],
+            [20260401.0, 1301.0, "A"],
+            [20260401.0, "", "empty"],
+            [20260401.0, None, "none"],
+        ]
+        result = self._run_with_rows(rows)
+        self.assertEqual(result, {"1301"})
+
+    def test_missing_code_column_raises(self):
+        rows = [
+            ["日付", "銘柄名", "市場"],
+            [20260401.0, "Alpha", "プライム"],
+        ]
+        with self.assertRaises(ValueError):
+            self._run_with_rows(rows)
+
+    def test_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            delisted_detector.load_jpx_listed_set("/does/not/exist.xls")
+
+
+class TestLoadRegionalSkipSet(unittest.TestCase):
+    """load_regional_skip_set() reads existing config file"""
+
+    def test_loads_actual_config(self):
+        config_path = os.path.join(
+            os.path.dirname(__file__), "..", "config", "stock_exchange_mapping.yml"
+        )
+        skip_set = delisted_detector.load_regional_skip_set(config_path)
+        # The real config has Nagoya / Fukuoka / Sapporo codes, at minimum.
+        self.assertGreater(len(skip_set), 10)
+        # Sanity: a known Nagoya code exists in the mapping.
+        self.assertIn("1738", skip_set)
+
+    def test_missing_file_returns_empty(self):
+        result = delisted_detector.load_regional_skip_set("/nonexistent/path.yml")
+        self.assertEqual(result, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- 上場廃止となった企業を検知して WebUI で視覚的に区別できるようにする。EDINET は有価証券報告書しか提供していないため、JPX が公開している「東証上場銘柄一覧」(data_j.xls) との差分で上場廃止銘柄を検出し、永続化する
- 検出ロジック: `delisted = (observed_secs - regional_skip) - jpx_listed` — `data/jsons/*.json` で過去に観測された全 secCode から、地方取引所単独上場銘柄 (`config/stock_exchange_mapping.yml`) を除いたうえで、現在の JPX listing にないものを delisted とみなす
- `data/edinet.json` に `isDelisted` / `delistedDate` を追加し、WebUI では `.delisted-row` で dim + 「廃止」バッジ表示

## 主な変更

- **新規**: `lib/delisted_detector.py` / `bin/update_delisted_companies.py` / `data/delisted_companies.yml` / テスト 2 本
- **変更**: `bin/consolidate_documents.py` (`--delisted` 引数), `docs/{index.html,script.js,styles.css}`, `.github/workflows/edinet-fetcher.yml`, `pyproject.toml` / `requirements.txt` に `xlrd==1.2.0` ピン

## 重要な技術判断

- **xlrd を直接使用 (pandas 非経由)**: pandas 2.x は `xlrd>=2.0.1` を要求するが、xlrd 2.x は `.xls` 非対応。両立しないため `xlrd.open_workbook()` を直接呼ぶ
- **`stock_exchange_mapping.yml` は判定スキップリスト**: ホワイトリスト扱いしない (mapping 未登録銘柄の誤検出は既存の quarterly update 運用で拾う)
- **JPX 取得失敗の段階的エスカレーション**: 1 連続 → stderr warning / 2 連続 → `\$GITHUB_STEP_SUMMARY` に警告 / 3 連続 → `exit 1`。連続失敗カウンタは `metadata.consecutive_failures` に永続化
- **workflow 順**: fetch → update → consolidate (update は `data/jsons/` のみ参照し、`edinet.json` に依存しない)

## 初期検出結果

約 200 件の上場廃止銘柄を検出 (直近の TOB/MBO が大半):
- イオンモール (8905), SCSK (9719), NTTデータグループ (9613), ベネッセHD (9783), ＳＢＩレオスひふみ (165A), ダイセキ環境ソリューション (1712), 富士ソフト (9749), インプレスHD (9479) など
- 400 日窓に入る 107 件が `edinet.json` に `isDelisted: true` で反映

## Test plan

- [x] `uv run python -m pytest tests/test_delisted_detector.py tests/test_consolidate_delisted.py -v` — 33 件すべて PASS
- [x] `uv run python bin/update_delisted_companies.py ...` 手動実行で `data/delisted_companies.yml` 生成確認
- [x] `uv run python bin/consolidate_documents.py ... --delisted data/delisted_companies.yml` で `isDelisted` フィールド付与確認
- [x] Playwright でローカル HTTP サーバを起動し、Light/Dark 両モードで `.delisted-row` の dim + 廃止バッジ + strike-through の視覚確認
- [x] 既存の pytest suite で新機能が壊していないことを確認 (事前の failing 3 件は stock_exchange_mapping テストの pre-existing 失敗で本 PR 無関係)
- [ ] GitHub Actions のワークフローが緑で通ること