### PR TITLE
chore: de-duplicate *.log in .gitignore (#164)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,7 +203,6 @@ cython_debug/
 investigate_*.py
 analyze_*.py
 *_debug.py
-*.log
 XBRL_*.md
 xbrl_*_investigation_*.json
 


### PR DESCRIPTION
## Summary
Sub-task **6/6** of #158. Tightens `.gitignore`. Independent of all other sub-issues.

- Remove the redundant second `*.log` entry (kept the canonical one in the Python-template block).

## ⚠️ Scoped to reality (verified)
The artifacts named in the issue do **not** exist and `*.log` is already ignored, so this is effectively a cleanup-only change:
- `summary.json`, `test.tar.gz`, `uv-debug.log` → **not present** in the repo → no entries added (per `--no-fabrication`).
- `git ls-files '*.log'` → **empty** (no tracked logs) → no `git rm` needed.
- Two untracked dated run logs (`consolidate_documents_*.log`, `update_delisted_companies_*.log`) were removed from the **local working tree only** (already ignored, never tracked).

## Verification
- `grep -c '^\*\.log' .gitignore` → `1` (was `2`).
- `git check-ignore foo.log` → still ignored.

Refs #158, closes #164