### PR TITLE
docs: rewrite CLAUDE.md into WHY/WHAT/HOW template (#163)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,96 +1,101 @@
 # CLAUDE.md
 
 このファイルはClaude Code (claude.ai/code)がこのリポジトリで作業する際のガイダンスです。
+**WHY（なぜ） / WHAT（なにを） / HOW（どうやって）** の3部構成で記述します。
 
-## プロジェクト概要
+---
 
-**edinet** - EDINETから上場企業の開示情報を取得・処理するツール
-- EDINET: 日本の企業情報電子開示システム
-- 日次で財務データを自動取得し、構造化されたJSONとして保管
-- Python 3.x + requests/lxml/argparse/playwright
+## WHY — 目的と背景
 
-## アーキテクチャ
+**edinet** は、EDINET（日本の企業情報電子開示システム）から上場企業の開示情報を取得・処理するツールです。
+
+- **目的**: 上場企業の財務データを日次で自動取得し、構造化されたJSONとして保管・公開する。
+- **背景**: EDINETは有価証券報告書等を提供するが、機械可読な統合データセットは提供しない。本ツールはXBRLを解析し、Yahoo Financeの市場データで補完して、横断分析可能なデータセットを生成する。
+- **公開**: 生成データはWebビューア（`web/`）とともにGitHub Pages（`gh-pages`ブランチ）で `https://mikanmarusan.net/edinet/` に公開される。
+- **技術スタック**: Python 3.x + requests / lxml / argparse / playwright
+
+---
+
+## WHAT — アーキテクチャと設計判断
+
+### ディレクトリ構成
 
 ```
 edinet/
-├── bin/                    # 実行可能スクリプト
-├── lib/                    # 共有ライブラリ
-│   ├── edinet_common.py   # EDINET API共通処理
-│   ├── xbrl_parser.py     # XBRL解析処理
-│   ├── ticker_generator.py # Yahoo Finance用ティッカー生成
-│   ├── url_generator.py   # Yahoo Finance URL生成
-│   └── data_scraper.py    # Yahoo Financeスクレイピング
-├── data/jsons/            # 出力データ
-└── .claude/               # Claude Code用の詳細ルール
+├── bin/                     # 実行可能スクリプト
+├── lib/                     # 共有ライブラリ
+│   ├── edinet_common.py     # EDINET API共通処理
+│   ├── xbrl_parser.py       # XBRL解析処理
+│   ├── ticker_generator.py  # Yahoo Finance用ティッカー生成
+│   ├── url_generator.py     # Yahoo Finance URL生成
+│   └── data_scraper.py      # Yahoo Financeスクレイピング
+├── data/jsons/              # 出力データ（日次JSON）
+├── data/edinet.json         # 統合データ
+├── web/                     # 公開Webビューアのソース（gh-pagesへ配信）
+├── docs/                    # 内部ドキュメント（GitHub Pages非公開）
+│   ├── architecture.md      # アーキテクチャ設計
+│   ├── context/             # プロダクト要件・XBRL知見・変更履歴
+│   └── examples/            # 実装パターン例
+├── .github/                 # ワークフロー・Issue/PRテンプレート
+└── .claude/                 # Claude Code用ルール・スキル・設定
+    ├── rules/               # 開発ルール・ガイドライン
+    ├── skills/              # スキル（例: update-stock-exchange-mapping）
+    ├── agents/              # エージェント定義
+    └── settings.json
 ```
 
-## 重要な設計原則
+> **ボイラープレートからの意図的な逸脱**: 本プロジェクトはPythonプロジェクトとして `src/` を導入せず、既存の `bin/`（実行可能スクリプト）+ `lib/`（共有モジュール）構成を維持する。これは確立された慣習に基づく意図的な設計判断である。
+
+### ドキュメント・ファイル配置の方針
+
+それぞれの配置先は「役割」で決める。新たにドキュメントやファイルを追加する際の指針：
+
+- **`docs/`（プロジェクトの背景・仕様・知識 = What/Why）**: このプロジェクトを理解するための背景情報。プロダクト要件、アーキテクチャ、ドメイン知識、変更履歴など。
+- **`docs/examples/`（コード例・実装パターン）**: 具体的なコードやその解説。実装パターン、データ抽出例、エラーハンドリング例など。
+- **`.claude/rules/`（手順書・ガイドライン・ルール = How）**: 何かを実行するための手順やルール。開発手順、コーディング規約、デプロイ手順、テスト方法など。
+- **`.claude/skills/`（スキル）**: Claude Codeが実行する自動化スキル（`SKILL.md` 形式）。
+- **`.claude/agents/`（エージェント定義）**: サブエージェント定義。
+- **`.github/`（雛形・テンプレート）**: そのままコピーして使うことを想定したファイル。Issue/PRテンプレートなど。
+
+### 公開（GitHub Pages）
+
+- 公開ソースは `gh-pages` ブランチ。`.github/workflows/deploy-pages.yml` が `web/*` と `data/edinet.json`（`data.json` にリネーム）を公開する。
+- `edinet` は独自ドメインを持たない**プロジェクトサイト**で、apexドメイン `mikanmarusan.net` はユーザーサイト側が保有する。**このリポジトリに `CNAME` ファイルを置いてはならない**（apexドメインと衝突するため）。
+
+### 重要な設計原則
 
 1. **DRY**: lib/モジュールで共通処理を集約
 2. **フェイルセーフ**: 個別エラーで全体停止を避ける
 3. **明示的 > 暗黙的**: 必須パラメータにデフォルト値なし
 4. **API制限遵守**: 1リクエスト/秒
 
-## 開発規約
-
-### 基本ルール
-- Python PEP 8準拠
-- 関数名: snake_case、定数: UPPER_SNAKE_CASE
-- エラーは個別処理しログ記録
-
 ### データ形式
+
 - 証券コード: 4桁（末尾0削除）
 - 決算期: YYYY年M月期（先頭0なし）
 - 財務データ優先: 連結 > 個別、当期 > 過去
 
-## .claude/ディレクトリ構造の定義
+### 最近の重要な更新
 
-### context/ - プロジェクトの背景・仕様・知識
-- **役割**: プロジェクトの「What」と「Why」を説明
-- **配置基準**: このプロジェクトを理解するために必要な背景情報
-- **内容例**: プロダクト要件、アーキテクチャ、ドメイン知識、変更履歴
+**Yahoo Finance統合の完了（2025年7月）**: Yahoo Financeデータとの統合により、新たに以下のフィールドが追加された。
 
-### instructions/ - 手順書・ガイドライン・ルール  
-- **役割**: 作業の「How」を説明
-- **配置基準**: 何かを実行するための手順やルール
-- **内容例**: 開発手順、コーディング規約、デプロイ手順、テスト方法
+- **ordinaryIncome**: 経常利益
+- **ordinaryIncomeRate**: 経常利益率
+- **issuedDate**: 有価証券報告書の提出日
 
-### examples/ - コード例・実装パターン
-- **役割**: 「実際のコード」を示す
-- **配置基準**: 具体的なコードやその解説
-- **内容例**: 実装パターン、データ抽出例、エラーハンドリング例
+詳細な変更履歴と技術的な学習事項は `docs/context/changelog.md` を参照。
 
-### templates/ - 雛形・テンプレート
-- **役割**: 「コピーして使う」ファイル
-- **配置基準**: そのままコピーして使うことを想定したファイル
-- **内容例**: Issue/PRテンプレート、設定ファイルの雛形
+---
 
-## 詳細ルールへの参照
+## HOW — 開発ワークフロー
 
-詳細は`.claude/`ディレクトリ内のドキュメントを参照：
+### コーディング規約（基本ルール）
 
-### context/ - プロジェクトコンテキスト
-- `product-requirements.md` - プロダクト要件
-- `architecture.md` - アーキテクチャ設計
-- `xbrl-taxonomy-notes.md` - XBRL構造の理解と学習事項
-- `changelog.md` - 変更履歴・学習事項
+- Python PEP 8準拠
+- 関数名: snake_case、定数: UPPER_SNAKE_CASE
+- エラーは個別処理しログ記録
 
-### instructions/ - 開発指示
-- `coding-standards.md` - コーディング規約
-- `git-workflow.md` - Git運用ルール
-- `security.md` - セキュリティ指針
-- `documentation.md` - ドキュメント作成
-- `debugging-guide.md` - デバッグ手法
-- `deployment.md` - デプロイ設定
-- `performance-guidelines.md` - パフォーマンス最適化
-- `testing-guidelines.md` - テスト戦略
-- `web-viewer-guide.md` - Webビューア実装
-
-### examples/ - 実装例とガイド
-- `development-patterns.md` - 開発パターン
-- `xbrl-extraction-patterns.md` - XBRL抽出パターン例
-
-## クイックリファレンス
+### クイックリファレンス
 
 **日次データ取得**:
 ```bash
@@ -103,9 +108,9 @@ python bin/fetch_edinet_financial_documents.py --date YYYY-MM-DD --outputdir dat
 python bin/consolidate_documents.py --inputdir data/jsons --output data/edinet.json
 ```
 
-## Issue対応時の必須事項
+### Issue対応時の必須事項
 
-### 開発手順（必ず順番通りに実行）
+#### 開発手順（必ず順番通りに実行）
 1. **ブランチ作成**: `git checkout -b fix/issue-{番号}-{簡潔な説明}`
 2. **実装**: コード変更を実施
 3. **テスト実行**: `python -m pytest tests/ -v`
@@ -114,27 +119,45 @@ python bin/consolidate_documents.py --inputdir data/jsons --output data/edinet.j
    - 例: `fix: improve company characteristic extraction logic`
 5. **PR作成**: 必要に応じてPull Requestを作成
 
-### Issueフォーマット
+#### Issueフォーマット
 - Goal: 達成したい目的
 - Return Format: 期待される成果物
 - Warnings: 注意点（なければ「なし」）
 - Additional Context: 関連情報（なければ「なし」）
 
-### 重要な注意事項
+#### 重要な注意事項
 - **mainブランチでの直接作業は厳禁**
 - 必ず機能ブランチを作成してから作業を開始すること
 - テストが通ることを確認してからコミットすること
 
-## 開発時の注意
+### 詳細ドキュメントへの参照
 
-新機能追加やバグ修正の際は、必ず`.claude/`配下の関連ドキュメントを参照してください。
+新機能追加やバグ修正の際は、必ず以下の関連ドキュメントを参照すること。
 
-## 最近の重要な更新
+**プロジェクトコンテキスト（`docs/`）**
+- `docs/architecture.md` - アーキテクチャ設計
+- `docs/context/product-requirements.md` - プロダクト要件
+- `docs/context/xbrl-taxonomy-notes.md` - XBRL構造の理解と学習事項
+- `docs/context/changelog.md` - 変更履歴・学習事項
 
-### Yahoo Finance統合の完了（2025年7月）
-Yahoo Financeデータとの統合により、新たに以下のフィールドが追加されました：
-- **ordinaryIncome**: 経常利益
-- **ordinaryIncomeRate**: 経常利益率
-- **issuedDate**: 有価証券報告書の提出日
+**開発ルール（`.claude/rules/`）**
+- `coding-standards.md` - コーディング規約
+- `git-workflow.md` - Git運用ルール
+- `security.md` - セキュリティ指針
+- `documentation.md` - ドキュメント作成
+- `debugging-guide.md` - デバッグ手法
+- `deployment.md` - デプロイ設定
+- `performance-guidelines.md` - パフォーマンス最適化
+- `testing-guidelines.md` - テスト戦略
+- `web-viewer-guide.md` - Webビューア実装
 
-詳細な変更履歴と技術的な学習事項は `.claude/context/changelog.md` を参照してください。
+**実装例（`docs/examples/`）**
+- `development-patterns.md` - 開発パターン
+- `xbrl-extraction-patterns.md` - XBRL抽出パターン例
+
+**スキル（`.claude/skills/`）**
+- `update-stock-exchange-mapping/` - 地方取引所マッピングの四半期更新
+
+**テンプレート（`.github/`）**
+- `.github/ISSUE_TEMPLATE/issue-template.md` - Issueテンプレート
+- `.github/PULL_REQUEST_TEMPLATE.md` - PRテンプレート


### PR DESCRIPTION
## Summary
Sub-task **5/6** of #158. Reorganizes `CLAUDE.md` into the **WHY / WHAT / HOW** template, preserving all existing content.

> **Re-targeted to `main`.** The original PR #173 was accidentally merged into its stacked base (`docs/162-relocate-docs`) instead of `main`, so the rewrite never reached `main`. This PR lands the same commit directly on `main`. Diff is **CLAUDE.md only** (PR #172's relocations are already on `main`).

- WHY: purpose/background of fetching EDINET disclosures.
- WHAT: architecture, `bin/`+`lib/` (not `src/`) deviation note, doc-placement criteria (remapped), GitHub Pages/`gh-pages` + no-CNAME constraint, design principles, data-format rules, recent updates.
- HOW: coding standards, quick reference, issue workflow, doc-pointers updated to the post-relocation layout.

## Verification
- Diff vs `main` is `CLAUDE.md` only.
- All doc-pointer paths referenced in `CLAUDE.md` exist on `main`.

Refs #158, closes #163