### PR TITLE
chore(gitignore): ignore repo-root .plans/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,6 @@ xbrl_*_investigation_*.json
 
 # Claude Code local planning notes (not committed)
 .claude/plans/
+
+# Repo-root local planning notes (not committed)
+.plans/


### PR DESCRIPTION
## Summary
Stops the repo-root `.plans/` directory (local-only planning notes) from being accidentally committed by `git add -A` / `git add .`. The earlier `.claude/plans/` rule (from #161) does not cover this path because the planning directory actually in use is the repo root `.plans/`.

## Changes
- Append `.plans/` to `.gitignore`, with a comment marking it as repo-root local planning notes.
- Existing `.claude/plans/` entry left untouched (no regression).

## Verification
Lint/typecheck/test: not applicable — this is a `.gitignore`-only change; the repo defines no `package.json` or `Makefile` lint/typecheck/test commands.

Code review (x-code-reviewer): zero Critical, zero Warning. One optional Suggestion to anchor the pattern as `/.plans/`; declined to keep stylistic consistency with the unanchored sibling `.claude/plans/` entry.

Acceptance criteria:
- MET - Append `.plans/` to `.gitignore`: `git diff main` shows the 3-line additive change.
- MET - `git check-ignore .plans/foo.md` reports it as ignored: prints `.plans/foo.md` (exit 0).
- MET - No `.plans/` files tracked: `git ls-files .plans/` is empty, so no `git rm --cached` needed.
- MET - Warning (no deletion of local contents): only `.gitignore` changed (`git diff main --name-only`); local `.plans/` files remain present.
- MET - Warning (no `.claude/plans/` regression): entry still present at `.gitignore:214`.

Closes #175