### PR TITLE
fix(xbrl): resolve taxonomy namespace per document, prefer NetAssets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,3 +161,10 @@ python bin/consolidate_documents.py --inputdir data/jsons --output data/edinet.j
 **テンプレート（`.github/`）**
 - `.github/ISSUE_TEMPLATE/issue-template.md` - Issueテンプレート
 - `.github/PULL_REQUEST_TEMPLATE.md` - PRテンプレート
+
+---
+
+## Lessons
+
+- 新しいモジュールレベルの定数やデータテーブル（許可リスト等）を追加するときは、その定数が記述する振る舞いを検証するテストから必ず参照すること。参照されない定数はデッドコードとして扱われる。
+- 外部のXML/テキストを正規表現で解析するときは、よくあるケースだけでなく有効な入力のすべての異形（例: XML属性値のシングルクォートとダブルクォートの両方）を受け付けること。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,5 @@
 # Architecture
+<!-- spec-synced-through: 2d06092c9eccb02a538982af73dd7559a726253f -->
 
 ## Development Architecture
 
@@ -11,7 +12,7 @@ The system uses a modular architecture with shared utilities:
 
 ### Key Shared Components
 - EDINET API configuration and rate limiting
-- XBRL namespace mappings for EDINET 2024-11-01 taxonomy  
+- XBRL namespace mappings resolved per document from the filing's declared taxonomy edition (`detect_taxonomy_namespaces`), with the EDINET 2024-11-01 mappings as fallback defaults  
 - Common logging and error handling
 - Data validation and formatting utilities
 
@@ -104,6 +105,19 @@ else:
 - `_dynamic_search_*`: All dynamic search methods check consolidated data availability
 - Priority calculation methods: `_calculate_*_priority()` for consistent scoring
 - Pattern matching maintains backward compatibility for companies with consolidated data
+
+### Per-Document Taxonomy & XBRL Hardening (2026-06 Update)
+
+#### Per-Document Namespace Resolution
+- EDINET taxonomy editions coexist by fiscal period (e.g. 2024-11-01 and 2025-11-01), so a hardcoded namespace map silently returns null for filings on a newer edition.
+- `detect_taxonomy_namespaces()` (lib/edinet_common.py) reads the `jpcrp_cor`/`jppfs_cor`/`jpigp_cor`/`jpdei_cor` xmlns URIs actually declared by each document and merges them over the static defaults; it is fail-safe and logs a WARNING when no known taxonomy resolves.
+- `parse_financial_data()` assigns the resolved map to the (reused) extractor instance per document. Detected URIs are used only as `findall` dict values, never dereferenced.
+
+#### Equity Concept Selection
+- `equity` prioritizes NetAssets (純資産合計) over ShareholdersEquity (株主資本); intentional value changes are tracked in the `EXPECTED_EQUITY_CHANGES` allowlist.
+
+#### XML Hardening
+- The XBRL parse path uses `defusedxml.ElementTree.fromstring` to reject XML entity-expansion ("billion laughs") payloads.
 
 ### Yahoo Finance Integration Architecture (2025-07)
 

--- a/lib/edinet_common.py
+++ b/lib/edinet_common.py
@@ -6,11 +6,16 @@ Shared utilities, configurations, and logging setup for EDINET tools.
 """
 
 import logging
+import re
 import sys
 import os
 import yaml
 from datetime import datetime
 from typing import Optional, Dict, Any
+
+
+# Module-level logger for standalone functions
+logger = logging.getLogger(__name__)
 
 
 # EDINET API Configuration
@@ -29,6 +34,29 @@ XBRL_NAMESPACES = {
     'iso4217': 'http://www.xbrl.org/2003/iso4217',
     'xbrldi': 'http://xbrl.org/2006/xbrldi',
     'xsi': 'http://www.w3.org/2001/XMLSchema-instance'
+}
+
+# Taxonomy editions that EDINET ships and that coexist by fiscal period.
+# Detected URIs (see detect_taxonomy_namespaces) merge over the static defaults.
+KNOWN_TAXONOMY_PREFIXES = ('jpcrp_cor', 'jppfs_cor', 'jpigp_cor', 'jpdei_cor')
+
+# Regex over raw XBRL bytes capturing taxonomy xmlns declarations, e.g.
+#   xmlns:jppfs_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2025-11-01/jppfs_cor"
+# Both double- and single-quoted attribute values are accepted (XML permits both).
+_TAXONOMY_NS_RE = re.compile(
+    rb'xmlns:(jpcrp_cor|jppfs_cor|jpigp_cor|jpdei_cor)\s*=\s*(?:"([^"]+)"|\'([^\']+)\')'
+)
+
+# Companies whose `equity` value intentionally changes once NetAssets (純資産合計)
+# is preferred over ShareholdersEquity (株主資本). This is a fix, not a regression;
+# the allowlist records the verified expected values for traceability.
+EXPECTED_EQUITY_CHANGES = {
+    '1301': {
+        'concept': 'NetAssets',
+        'expected_equity': 63189000000,
+        'previous_concept': 'ShareholdersEquity',
+        'previous_equity': 78868000000,
+    },
 }
 
 # XBRL field patterns for financial data extraction
@@ -167,6 +195,14 @@ XBRL_PATTERNS = {
         './/jppfs_cor:ShareholdersEquityPerShare'
     ],
     'equity': [
+        # Net assets (純資産合計 / NetAssets) - highest priority (issue #182).
+        # 純資産合計 is the correct equity concept; 株主資本 (ShareholdersEquity)
+        # excludes non-controlling interests and was previously selected by mistake.
+        './/jpcrp_cor:NetAssets',
+        './/jppfs_cor:NetAssets',
+        './/jpcrp_cor:NetAssetsSummaryOfBusinessResults',
+        './/jppfs_cor:NetAssetsSummaryOfBusinessResults',
+
         # Consolidated equity patterns (priority)
         './/jpcrp_cor:ConsolidatedShareholdersEquity',
         './/jppfs_cor:ConsolidatedShareholdersEquity',
@@ -483,6 +519,51 @@ XBRL_PATTERNS = {
         './/jppfs_cor:CashAndShortTermInvestments'
     ]
 }
+
+
+def detect_taxonomy_namespaces(raw_bytes: bytes) -> Dict[str, str]:
+    """
+    Detect EDINET taxonomy namespace URIs from raw XBRL bytes.
+
+    EDINET taxonomy editions coexist by fiscal period (e.g. 2024-11-01 and
+    2025-11-01). The static XBRL_NAMESPACES map hardcodes a single edition, so a
+    namespace-prefixed findall silently returns nothing for filings that use a
+    different edition. This reads the actual xmlns declarations from the document
+    and merges them over the static defaults.
+
+    The function is fail-safe: any error falls back to the static defaults so a
+    malformed header never aborts parsing.
+
+    Args:
+        raw_bytes: Raw XBRL instance document bytes
+
+    Returns:
+        A namespace map (copy of XBRL_NAMESPACES) with any detected taxonomy
+        URIs merged in. Detected URIs are used ONLY as findall dict values and
+        are never dereferenced (no network or file access).
+    """
+    namespaces = dict(XBRL_NAMESPACES)
+    try:
+        detected = {}
+        for match in _TAXONOMY_NS_RE.finditer(raw_bytes):
+            prefix = match.group(1).decode('ascii')
+            # Group 2 = double-quoted value, group 3 = single-quoted value.
+            uri = (match.group(2) or match.group(3)).decode('utf-8')
+            detected[prefix] = uri
+
+        if detected:
+            namespaces.update(detected)
+        else:
+            logger.warning(
+                "No known EDINET taxonomy namespace (%s) found in XBRL; "
+                "using static defaults. EDINET may have introduced a new "
+                "taxonomy edition.",
+                "/".join(KNOWN_TAXONOMY_PREFIXES),
+            )
+    except Exception as e:
+        logger.warning("Failed to detect taxonomy namespaces, using defaults: %s", e)
+
+    return namespaces
 
 
 def setup_logging(script_name: str, verbose: bool = False) -> logging.Logger:

--- a/lib/xbrl_parser.py
+++ b/lib/xbrl_parser.py
@@ -13,7 +13,16 @@ import sys
 from datetime import datetime
 from typing import Dict, Any, Optional, List
 
-from .edinet_common import XBRL_NAMESPACES, XBRL_PATTERNS, XBRLParsingError, format_period_end, get_stock_exchange_code
+from defusedxml.ElementTree import fromstring as defused_fromstring
+
+from .edinet_common import (
+    XBRL_NAMESPACES,
+    XBRL_PATTERNS,
+    XBRLParsingError,
+    format_period_end,
+    get_stock_exchange_code,
+    detect_taxonomy_namespaces,
+)
 
 
 class XBRLExtractor:
@@ -723,9 +732,14 @@ class XBRLParser:
             if not main_xbrl:
                 raise XBRLParsingError("No main XBRL document found")
             
-            # Parse XML content
-            root = ET.fromstring(main_xbrl)
-            
+            # Parse XML content (defused against XML entity-expansion attacks)
+            root = defused_fromstring(main_xbrl)
+
+            # Resolve taxonomy namespaces per document: EDINET editions coexist
+            # by fiscal period, and the extractor instance is reused across
+            # documents, so the namespace map must be assigned for each one.
+            self.data_extractor.namespaces = detect_taxonomy_namespaces(main_xbrl)
+
             # Build financial data structure
             financial_data = self._build_financial_data_structure(
                 root, sec_code, filer_name, doc_id, period_end, issued_date, yahoo_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "PyYAML>=6.0",
     "playwright>=1.40.0",
     "xlrd==1.2.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ urllib3<2.0
 PyYAML>=6.0
 playwright>=1.40.0
 xlrd==1.2.0
+defusedxml>=0.7.1

--- a/tests/test_namespace_detection.py
+++ b/tests/test_namespace_detection.py
@@ -1,0 +1,207 @@
+"""
+Tests for per-document XBRL taxonomy namespace detection and XML hardening.
+
+Covers issue #182:
+- detect_taxonomy_namespaces resolves the taxonomy edition actually used by a
+  filing (editions coexist by fiscal period) and falls back to static defaults.
+- The XBRL_NAMESPACES re-export from lib.xbrl_parser stays intact.
+- The parse path is hardened against XML entity-expansion ("billion laughs").
+"""
+
+import io
+import unittest
+import zipfile
+
+from defusedxml.ElementTree import fromstring as defused_fromstring
+
+from lib.edinet_common import (
+    detect_taxonomy_namespaces,
+    XBRL_NAMESPACES,
+    EXPECTED_EQUITY_CHANGES,
+    XBRLParsingError,
+)
+from lib.xbrl_parser import XBRLParser, FinancialDataExtractor
+from lib.xbrl_parser import XBRL_NAMESPACES as REEXPORTED_XBRL_NAMESPACES
+
+
+NS_2025 = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance" '
+    b'xmlns:jpcrp_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/2025-11-01/jpcrp_cor" '
+    b'xmlns:jppfs_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2025-11-01/jppfs_cor" '
+    b'xmlns:jpdei_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jpdei/2013-08-31/jpdei_cor">'
+    b'</xbrli:xbrl>'
+)
+
+NS_2024 = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance" '
+    b'xmlns:jpcrp_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/2024-11-01/jpcrp_cor" '
+    b'xmlns:jppfs_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2024-11-01/jppfs_cor">'
+    b'</xbrli:xbrl>'
+)
+
+NS_ABSENT = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<root xmlns="http://www.example.com/none"></root>'
+)
+
+# Same 2025 edition, but with single-quoted xmlns values (XML permits both).
+NS_2025_SINGLE_QUOTED = (
+    b"<?xml version='1.0' encoding='UTF-8'?>"
+    b"<xbrli:xbrl xmlns:xbrli='http://www.xbrl.org/2003/instance' "
+    b"xmlns:jpcrp_cor='http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/2025-11-01/jpcrp_cor' "
+    b"xmlns:jppfs_cor='http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2025-11-01/jppfs_cor'>"
+    b"</xbrli:xbrl>"
+)
+
+# A 2025-edition document carrying both NetAssets (純資産合計) and the larger
+# ShareholdersEquity (株主資本) under a current-year context. Mirrors sec 1301.
+EQUITY_2025_DOC = (
+    b'<?xml version="1.0" encoding="UTF-8"?>'
+    b'<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance" '
+    b'xmlns:jppfs_cor="http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2025-11-01/jppfs_cor">'
+    b'<xbrli:context id="CurrentYearInstant">'
+    b'<xbrli:period><xbrli:instant>2025-03-31</xbrli:instant></xbrli:period>'
+    b'</xbrli:context>'
+    b'<jppfs_cor:NetAssets contextRef="CurrentYearInstant">63189000000</jppfs_cor:NetAssets>'
+    b'<jppfs_cor:ShareholdersEquity contextRef="CurrentYearInstant">78868000000</jppfs_cor:ShareholdersEquity>'
+    b'</xbrli:xbrl>'
+)
+
+# Classic "billion laughs" entity-expansion payload.
+BILLION_LAUGHS = (
+    b'<?xml version="1.0"?>'
+    b'<!DOCTYPE lolz ['
+    b'  <!ENTITY lol "lol">'
+    b'  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">'
+    b'  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">'
+    b'  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">'
+    b']>'
+    b'<lolz>&lol4;</lolz>'
+)
+
+
+def _make_xbrl_zip(xbrl_bytes: bytes) -> bytes:
+    """Wrap raw XBRL bytes in a ZIP that find_main_xbrl recognizes."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            'XBRL/PublicDoc/jpcrp030000-asr-001_E00000-000_2025-03-31_01_2025-06-30.xbrl',
+            xbrl_bytes,
+        )
+    return buffer.getvalue()
+
+
+class TestDetectTaxonomyNamespaces(unittest.TestCase):
+    """detect_taxonomy_namespaces resolves the edition used by each document."""
+
+    def test_detects_2025_edition(self):
+        """A 2025 inline doc resolves to 2025-11-01 taxonomy URIs."""
+        ns = detect_taxonomy_namespaces(NS_2025)
+        self.assertEqual(
+            ns['jpcrp_cor'],
+            'http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/2025-11-01/jpcrp_cor',
+        )
+        self.assertEqual(
+            ns['jppfs_cor'],
+            'http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2025-11-01/jppfs_cor',
+        )
+
+    def test_detects_2024_edition(self):
+        """A 2024 doc resolves to 2024-11-01 taxonomy URIs."""
+        ns = detect_taxonomy_namespaces(NS_2024)
+        self.assertEqual(
+            ns['jpcrp_cor'],
+            'http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/2024-11-01/jpcrp_cor',
+        )
+        self.assertEqual(
+            ns['jppfs_cor'],
+            'http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2024-11-01/jppfs_cor',
+        )
+
+    def test_falls_back_to_static_defaults(self):
+        """When no jpcrp/jppfs xmlns is present, the static defaults are returned."""
+        ns = detect_taxonomy_namespaces(NS_ABSENT)
+        self.assertEqual(ns, XBRL_NAMESPACES)
+
+    def test_does_not_mutate_static_defaults(self):
+        """The static XBRL_NAMESPACES map is never mutated by detection."""
+        before = dict(XBRL_NAMESPACES)
+        detect_taxonomy_namespaces(NS_2025)
+        self.assertEqual(XBRL_NAMESPACES, before)
+
+    def test_fail_safe_on_garbage_input(self):
+        """Non-XML bytes never raise; static defaults are returned."""
+        ns = detect_taxonomy_namespaces(b'\x00\x01not xml at all')
+        self.assertEqual(ns, XBRL_NAMESPACES)
+
+    def test_detects_single_quoted_namespaces(self):
+        """Single-quoted xmlns values resolve identically to double-quoted ones."""
+        ns = detect_taxonomy_namespaces(NS_2025_SINGLE_QUOTED)
+        self.assertEqual(
+            ns['jpcrp_cor'],
+            'http://disclosure.edinet-fsa.go.jp/taxonomy/jpcrp/2025-11-01/jpcrp_cor',
+        )
+        self.assertEqual(
+            ns['jppfs_cor'],
+            'http://disclosure.edinet-fsa.go.jp/taxonomy/jppfs/2025-11-01/jppfs_cor',
+        )
+
+
+class TestNamespaceReexport(unittest.TestCase):
+    """The XBRL_NAMESPACES re-export from lib.xbrl_parser must stay importable."""
+
+    def test_reexport_matches(self):
+        self.assertEqual(REEXPORTED_XBRL_NAMESPACES, XBRL_NAMESPACES)
+
+
+class TestEntityExpansionHardening(unittest.TestCase):
+    """The parse path rejects entity-expansion payloads instead of expanding them."""
+
+    def test_billion_laughs_raises(self):
+        parser = XBRLParser()
+        zip_bytes = _make_xbrl_zip(BILLION_LAUGHS)
+        with self.assertRaises(XBRLParsingError):
+            parser.parse_financial_data(
+                zip_bytes,
+                sec_code='0000',
+                filer_name='Test Co',
+                doc_id='TESTDOC',
+                period_end='2025-03-31',
+                issued_date='2025-06-30',
+            )
+
+
+class TestEquityNetAssetsExtraction(unittest.TestCase):
+    """NetAssets is selected over ShareholdersEquity, and only when the
+    per-document namespace map reaches extraction."""
+
+    def test_netassets_selected_with_detected_namespace(self):
+        """With the detected 2025 namespace, equity resolves to NetAssets."""
+        extractor = FinancialDataExtractor()
+        extractor.namespaces = detect_taxonomy_namespaces(EQUITY_2025_DOC)
+        root = defused_fromstring(EQUITY_2025_DOC)
+        value = extractor.extract_numeric_value_with_context(
+            root, extractor.patterns['equity'])
+        self.assertEqual(value, EXPECTED_EQUITY_CHANGES['1301']['expected_equity'])
+
+    def test_static_namespace_misses_2025_edition(self):
+        """With only the static 2024 defaults, the 2025-edition element is not
+        found - proving the per-document namespace assignment is load-bearing."""
+        extractor = FinancialDataExtractor()
+        extractor.namespaces = dict(XBRL_NAMESPACES)  # static defaults (2024-11-01)
+        root = defused_fromstring(EQUITY_2025_DOC)
+        value = extractor.extract_numeric_value_with_context(
+            root, extractor.patterns['equity'])
+        self.assertIsNone(value)
+
+    def test_allowlist_documents_expected_change(self):
+        """The allowlist records sec 1301's NetAssets concept and value."""
+        entry = EXPECTED_EQUITY_CHANGES['1301']
+        self.assertEqual(entry['concept'], 'NetAssets')
+        self.assertEqual(entry['expected_equity'], 63189000000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

PR1 of the XBRL-first re-architecture (#188). Fixes silent financial-data loss caused by a hardcoded XBRL taxonomy namespace, and corrects the `equity` concept to 純資産合計 (NetAssets). This is the foundation that unblocks re-enabling all XBRL extraction.

## Changes

- **Per-document namespace resolution**: add `detect_taxonomy_namespaces(raw_bytes)` to `lib/edinet_common.py`. It regex-detects the `jpcrp_cor`/`jppfs_cor`/`jpigp_cor`/`jpdei_cor` xmlns URIs actually declared by the filing (both single- and double-quoted) and merges them over the static `XBRL_NAMESPACES` defaults, fail-safe with a WARNING when no known taxonomy resolves. Detected URIs are used only as `findall` dict values, never dereferenced.
- **Per-document wiring**: in `lib/xbrl_parser.py` `parse_financial_data`, assign the resolved map to `self.data_extractor.namespaces` for each document (the extractor instance is reused across documents).
- **Equity = NetAssets**: add `NetAssets` (純資産合計) patterns as highest priority in the `equity` pattern list, ahead of `ShareholdersEquity` (株主資本). Record verified changes in an `EXPECTED_EQUITY_CHANGES` allowlist.
- **XML hardening**: swap `ET.fromstring` -> `defusedxml.ElementTree.fromstring` on the parse path to reject entity-expansion ("billion laughs") payloads; add `defusedxml` to `requirements.txt` and `pyproject.toml`.
- **Tests**: new `tests/test_namespace_detection.py` (11 cases).

## Verification

Commands run with the project venv interpreter (`.venv/bin/python`):

- [x] **Criterion 1 - MET**: `.venv/bin/python -m pytest tests/test_namespace_detection.py -v` -> 11 passed. Confirms 2025-11-01 URIs for a 2025 doc, 2024-11-01 for a 2024 doc, static defaults when no jpcrp/jppfs xmlns present.
- [ ] **Criterion 2 - verified-by-proxy; live re-fetch NOT runnable here**: re-fetching docID `S100YE8K` (sec 1301) to assert `equity == 63189000000` and `cash == 11047000000` requires a live EDINET API key and network, unavailable in the autonomous environment. The equity logic is proven by `TestEquityNetAssetsExtraction::test_netassets_selected_with_detected_namespace` (NetAssets 63189000000 selected over ShareholdersEquity 78868000000 in a 2025-edition doc) and `test_static_namespace_misses_2025_edition` (static defaults miss the 2025 element). **The live re-fetch and the `cash == 11047000000` assertion still need a human/CI run with an API key before merge** - hence this draft.
- [x] **Criterion 3 - MET**: `.venv/bin/python -c "from lib.xbrl_parser import XBRL_NAMESPACES"` succeeds; `.venv/bin/python -m pytest tests/ -v` -> 3 failed, 115 passed. The only failures are the 3 pre-existing `test_stock_exchange_mapping` cases (untouched by this diff). No new failures.
- [x] **Criterion 4 - MET**: `grep -n "defusedxml" requirements.txt pyproject.toml` shows the dependency in both; `.venv/bin/python -c "import defusedxml"` -> 0.7.1.
- [x] **Criterion 5 - MET**: `TestEntityExpansionHardening::test_billion_laughs_raises` passes - an entity-expansion payload through `parse_financial_data` raises `XBRLParsingError` instead of expanding.

Code review (x-code-reviewer): two Warnings from the first pass (single-quote regex gap; unused `EXPECTED_EQUITY_CHANGES`) were fixed and confirmed resolved in a second pass with zero Critical/Warning findings.

Closes #182
