### PR TITLE
refactor(xbrl): drop hardcoded equity allowlist, assert NetAssets rule generally

### DIFF
--- a/lib/edinet_common.py
+++ b/lib/edinet_common.py
@@ -47,18 +47,6 @@ _TAXONOMY_NS_RE = re.compile(
     rb'xmlns:(jpcrp_cor|jppfs_cor|jpigp_cor|jpdei_cor)\s*=\s*(?:"([^"]+)"|\'([^\']+)\')'
 )
 
-# Companies whose `equity` value intentionally changes once NetAssets (純資産合計)
-# is preferred over ShareholdersEquity (株主資本). This is a fix, not a regression;
-# the allowlist records the verified expected values for traceability.
-EXPECTED_EQUITY_CHANGES = {
-    '1301': {
-        'concept': 'NetAssets',
-        'expected_equity': 63189000000,
-        'previous_concept': 'ShareholdersEquity',
-        'previous_equity': 78868000000,
-    },
-}
-
 # XBRL field patterns for financial data extraction
 XBRL_PATTERNS = {
     'stock_price': [

--- a/tests/test_namespace_detection.py
+++ b/tests/test_namespace_detection.py
@@ -17,7 +17,6 @@ from defusedxml.ElementTree import fromstring as defused_fromstring
 from lib.edinet_common import (
     detect_taxonomy_namespaces,
     XBRL_NAMESPACES,
-    EXPECTED_EQUITY_CHANGES,
     XBRLParsingError,
 )
 from lib.xbrl_parser import XBRLParser, FinancialDataExtractor
@@ -55,8 +54,12 @@ NS_2025_SINGLE_QUOTED = (
     b"</xbrli:xbrl>"
 )
 
-# A 2025-edition document carrying both NetAssets (純資産合計) and the larger
-# ShareholdersEquity (株主資本) under a current-year context. Mirrors sec 1301.
+# A 2025-edition document carrying both NetAssets (純資産合計) and the smaller
+# ShareholdersEquity (株主資本) under a current-year context. Net assets always
+# exceed shareholders' equity (they additionally include non-controlling interests
+# and valuation adjustments); the values here are synthetic, not a real filing.
+EQUITY_NET_ASSETS = 5_000_000_000
+EQUITY_SHAREHOLDERS = 4_000_000_000
 EQUITY_2025_DOC = (
     b'<?xml version="1.0" encoding="UTF-8"?>'
     b'<xbrli:xbrl xmlns:xbrli="http://www.xbrl.org/2003/instance" '
@@ -64,8 +67,8 @@ EQUITY_2025_DOC = (
     b'<xbrli:context id="CurrentYearInstant">'
     b'<xbrli:period><xbrli:instant>2025-03-31</xbrli:instant></xbrli:period>'
     b'</xbrli:context>'
-    b'<jppfs_cor:NetAssets contextRef="CurrentYearInstant">63189000000</jppfs_cor:NetAssets>'
-    b'<jppfs_cor:ShareholdersEquity contextRef="CurrentYearInstant">78868000000</jppfs_cor:ShareholdersEquity>'
+    b'<jppfs_cor:NetAssets contextRef="CurrentYearInstant">5000000000</jppfs_cor:NetAssets>'
+    b'<jppfs_cor:ShareholdersEquity contextRef="CurrentYearInstant">4000000000</jppfs_cor:ShareholdersEquity>'
     b'</xbrli:xbrl>'
 )
 
@@ -174,17 +177,19 @@ class TestEntityExpansionHardening(unittest.TestCase):
 
 
 class TestEquityNetAssetsExtraction(unittest.TestCase):
-    """NetAssets is selected over ShareholdersEquity, and only when the
-    per-document namespace map reaches extraction."""
+    """NetAssets (純資産合計) is selected over ShareholdersEquity (株主資本), and
+    only when the per-document namespace map reaches extraction."""
 
-    def test_netassets_selected_with_detected_namespace(self):
-        """With the detected 2025 namespace, equity resolves to NetAssets."""
+    def test_netassets_preferred_over_shareholders_equity(self):
+        """With the detected 2025 namespace, equity resolves to NetAssets (the
+        total net assets), not the smaller ShareholdersEquity."""
         extractor = FinancialDataExtractor()
         extractor.namespaces = detect_taxonomy_namespaces(EQUITY_2025_DOC)
         root = defused_fromstring(EQUITY_2025_DOC)
         value = extractor.extract_numeric_value_with_context(
             root, extractor.patterns['equity'])
-        self.assertEqual(value, EXPECTED_EQUITY_CHANGES['1301']['expected_equity'])
+        self.assertEqual(value, EQUITY_NET_ASSETS)
+        self.assertNotEqual(value, EQUITY_SHAREHOLDERS)
 
     def test_static_namespace_misses_2025_edition(self):
         """With only the static 2024 defaults, the 2025-edition element is not
@@ -195,12 +200,6 @@ class TestEquityNetAssetsExtraction(unittest.TestCase):
         value = extractor.extract_numeric_value_with_context(
             root, extractor.patterns['equity'])
         self.assertIsNone(value)
-
-    def test_allowlist_documents_expected_change(self):
-        """The allowlist records sec 1301's NetAssets concept and value."""
-        entry = EXPECTED_EQUITY_CHANGES['1301']
-        self.assertEqual(entry['concept'], 'NetAssets')
-        self.assertEqual(entry['expected_equity'], 63189000000)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Follow-up cleanup to #189 (merged as 934e88d). The merge landed the working per-document namespace + NetAssets equity fix, but missed a later correction commit, so `main` still carries a hardcoded, mislabeled allowlist.

## Background

`EXPECTED_EQUITY_CHANGES` hardcoded sec 1301's equity figure with the 純資産合計 / 株主資本 labels **inverted**. Live verification (docID `S100YE8K`) showed:

- `NetAssets` (純資産合計, total) = 78,868M  ← correct `equity`
- `ShareholdersEquity` (株主資本) = 63,189M

The allowlist recorded `expected_equity: 63189000000` as "NetAssets", which is wrong. Production behavior is already correct (the NetAssets-first pattern resolves 78,868M); this PR only removes the dead, misleading constant and its test.

Verified general across accounting standards: 1301 (JP-GAAP -> `NetAssets`), 4689 / 7267 (IFRS -> `EquityIFRS`), all resolving to the NCI-inclusive total. No per-code special-casing, no hardcoded real figures.

## Changes

- Remove the `EXPECTED_EQUITY_CHANGES` allowlist from `lib/edinet_common.py`.
- Rewrite the equity test to assert the general rule (NetAssets preferred over the smaller ShareholdersEquity) with synthetic values instead of a real filing's figure.

## Verification

- `.venv/bin/python -m pytest tests/test_namespace_detection.py -q` -> 10 passed
- Full suite unchanged: only the 3 pre-existing `test_stock_exchange_mapping` failures remain.

Refs #182
