### PR TITLE
feat(fetch): add --no-market-data flag to skip Yahoo fetch

### DIFF
--- a/.github/workflows/edinet-fetcher.yml
+++ b/.github/workflows/edinet-fetcher.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Fetch financial documents from EDINET
       env:
         EDINET_API_KEY: ${{ secrets.EDINET_API_KEY }}
-      run: uv run python bin/fetch_edinet_financial_documents.py --date $(date -d "yesterday" '+%Y-%m-%d') --outputdir data/jsons --api-key $EDINET_API_KEY
+      run: uv run python bin/fetch_edinet_financial_documents.py --date $(date -d "yesterday" '+%Y-%m-%d') --outputdir data/jsons --api-key $EDINET_API_KEY --no-market-data
 
     # JPX data_j.xls との差分で上場廃止銘柄を検出し delisted_companies.yml を更新
     # 失敗時は段階的エスカレーション（1→warning / 2→step summary / 3→exit 1）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ edinet/
 ```bash
 python bin/fetch_edinet_financial_documents.py --date YYYY-MM-DD --outputdir data/jsons --api-key YOUR_KEY
 # 特定企業のみ: --sec-codes 7203,9984,4755
+# 市場データ取得をスキップ（Yahooにアクセスせず stockPrice/marketCapitalization と派生指標 per/pbr/ev/evPerEbitda を null にする）: --no-market-data
 ```
 
 **データ統合**:

--- a/bin/fetch_edinet_financial_documents.py
+++ b/bin/fetch_edinet_financial_documents.py
@@ -138,6 +138,12 @@ def main():
     parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
     parser.add_argument("--max-retries", type=int, default=3, help="Maximum number of retries for failed requests")
     parser.add_argument("--sec-codes", help="Comma-separated list of security codes to filter (e.g., 7203,9984)")
+    parser.add_argument(
+        "--no-market-data",
+        action="store_true",
+        help="Skip market-data fetch (Yahoo); stockPrice/marketCapitalization and "
+             "their derived metrics (per/pbr/ev/evPerEbitda) are left null",
+    )
     
     args = parser.parse_args()
     
@@ -212,17 +218,22 @@ def main():
                         logger.warning(f"Failed to download document for {filer_name} ({sec_code}): {e}")
                         break
                     
-                    # First, try to get data from Yahoo Finance
+                    # First, try to get data from Yahoo Finance (unless skipped).
+                    # When --no-market-data is set, leave yahoo_data None so the
+                    # market fields and their derived metrics stay null.
                     yahoo_data = None
-                    try:
-                        logger.info(f"Fetching Yahoo Finance data for {sec_code}...")
-                        # Convert period_end to Yahoo Finance format (YYYY年M月期)
-                        formatted_period_end = format_period_end(period_end)
-                        yahoo_data = get_financial_data(sec_code, formatted_period_end)
-                        logger.info(f"Successfully fetched Yahoo Finance data for {sec_code}")
-                    except Exception as yahoo_error:
-                        logger.warning(f"Failed to fetch Yahoo Finance data for {sec_code}: {yahoo_error}")
-                        # Continue with XBRL parsing even if Yahoo fails
+                    if args.no_market_data:
+                        logger.debug(f"Skipping market-data fetch for {sec_code} (--no-market-data)")
+                    else:
+                        try:
+                            logger.info(f"Fetching Yahoo Finance data for {sec_code}...")
+                            # Convert period_end to Yahoo Finance format (YYYY年M月期)
+                            formatted_period_end = format_period_end(period_end)
+                            yahoo_data = get_financial_data(sec_code, formatted_period_end)
+                            logger.info(f"Successfully fetched Yahoo Finance data for {sec_code}")
+                        except Exception as yahoo_error:
+                            logger.warning(f"Failed to fetch Yahoo Finance data for {sec_code}: {yahoo_error}")
+                            # Continue with XBRL parsing even if Yahoo fails
                     
                     # Parse financial data with Yahoo data if available
                     financial_data = xbrl_parser.parse_financial_data(
@@ -272,10 +283,13 @@ def main():
         logger.info(f"  Total documents processed: {len(documents)}")
         logger.info(f"  Successful extractions: {successful_extractions}")
         logger.info(f"  Failed extractions: {failed_extractions}")
-        logger.info(
-            f"  Market-data nulls: stockPrice={data_scraper.market_null_counts['stockPrice']}, "
-            f"marketCapitalization={data_scraper.market_null_counts['marketCapitalization']}"
-        )
+        if args.no_market_data:
+            logger.info("  Market-data fetch skipped (--no-market-data); market fields left null")
+        else:
+            logger.info(
+                f"  Market-data nulls: stockPrice={data_scraper.market_null_counts['stockPrice']}, "
+                f"marketCapitalization={data_scraper.market_null_counts['marketCapitalization']}"
+            )
         logger.info(f"  Output file: {output_file}")
         
     except KeyboardInterrupt:

--- a/tests/test_no_market_data_flag.py
+++ b/tests/test_no_market_data_flag.py
@@ -1,0 +1,94 @@
+"""Tests for the --no-market-data flag of fetch_edinet_financial_documents.
+
+The flag must skip the market-data (Yahoo) fetch entirely: get_financial_data
+is not called, and the parser receives yahoo_data=None so the market fields and
+their derived metrics are left null. Without the flag, the fetch runs as before.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add parent directory to path so the script's `from lib...` imports resolve.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+_BIN_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "bin",
+    "fetch_edinet_financial_documents.py",
+)
+
+
+def _load_fetch_module():
+    """Import the bin script as a module so its main() can be driven directly."""
+    spec = importlib.util.spec_from_file_location("fetch_edinet_main", _BIN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestNoMarketDataFlag(unittest.TestCase):
+    """Verify the --no-market-data flag controls whether Yahoo is fetched."""
+
+    def setUp(self):
+        self.fetch = _load_fetch_module()
+        self.tmpdir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "_tmp_no_market_data"
+        )
+        os.makedirs(self.tmpdir, exist_ok=True)
+
+    def tearDown(self):
+        out = os.path.join(self.tmpdir, "2023-06-22.json")
+        if os.path.exists(out):
+            os.remove(out)
+        if os.path.isdir(self.tmpdir):
+            os.rmdir(self.tmpdir)
+
+    def _run_main(self, extra_args):
+        """Drive main() with a single fake document and mocked dependencies."""
+        argv = [
+            "fetch_edinet_financial_documents.py",
+            "--date", "2023-06-22",
+            "--outputdir", self.tmpdir,
+            "--api-key", "dummy-key-1234567890",
+        ] + extra_args
+
+        fake_client = MagicMock()
+        fake_client.get_documents.return_value = [
+            {"docID": "S100TEST", "secCode": "9999", "filerName": "テスト株式会社",
+             "periodEnd": "2023-03-31"}
+        ]
+        fake_client.download_document.return_value = b"dummy-xbrl-bytes"
+
+        with patch.object(sys, "argv", argv), \
+                patch.object(self.fetch, "EdinetClient", return_value=fake_client), \
+                patch.object(self.fetch, "XBRLParser") as mock_parser_cls, \
+                patch.object(self.fetch, "get_financial_data") as mock_get_fin:
+            mock_parser_cls.return_value.parse_financial_data.return_value = {
+                "secCode": "9999", "stockPrice": None, "marketCapitalization": None,
+            }
+            mock_get_fin.return_value = {"stockPrice": 1000.0,
+                                         "marketCapitalization": 9_000_000_000}
+            self.fetch.main()
+            return mock_get_fin, mock_parser_cls.return_value.parse_financial_data
+
+    def test_flag_skips_yahoo_fetch(self):
+        """With --no-market-data, get_financial_data is never called and the
+        parser receives yahoo_data=None."""
+        mock_get_fin, mock_parse = self._run_main(["--no-market-data"])
+        mock_get_fin.assert_not_called()
+        # yahoo_data is the 7th positional arg of parse_financial_data.
+        call = mock_parse.call_args
+        yahoo_data = call.args[6] if len(call.args) > 6 else call.kwargs.get("yahoo_data")
+        self.assertIsNone(yahoo_data)
+
+    def test_without_flag_fetches_yahoo(self):
+        """Without the flag, get_financial_data is called as before."""
+        mock_get_fin, _ = self._run_main([])
+        mock_get_fin.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a `--no-market-data` flag to the daily EDINET fetch script so it can run without contacting Yahoo Finance. Yahoo has begun returning HTTP 500 / soft-block pages (IP-level anti-scraping) for the quote pages, and the scrape is ToS-prohibited to begin with. With the flag set, the market fields and their dependent metrics are simply left null instead of triggering failed fetches. The flag is enabled in the scheduled `edinet-fetcher` workflow.

## Changes
- Add `--no-market-data` flag to `bin/fetch_edinet_financial_documents.py`; when set, `get_financial_data` (Yahoo) is not called and `yahoo_data=None` is passed to the parser, leaving `stockPrice`/`marketCapitalization` and derived metrics (`per`/`pbr`/`ev`/`evPerEbitda`) null. The run summary reports the skip instead of misleading null counts.
- Enable `--no-market-data` in `.github/workflows/edinet-fetcher.yml` so scheduled runs no longer depend on the block-prone Yahoo scrape.
- Add `tests/test_no_market_data_flag.py` verifying the flag skips the Yahoo fetch and that the normal path still fetches.
- Document the flag in `CLAUDE.md` quick reference.