### PR TITLE
docs(testing): reflect existing pytest suite and CI matrix

### DIFF
--- a/.claude/rules/testing-guidelines.md
+++ b/.claude/rules/testing-guidelines.md
@@ -1,29 +1,52 @@
 # Testing Strategy
 
-## テスト戦略
+## 現在のテスト状況
 
-### 現在のテスト状況
-- 明示的なテストスイートは未実装
-- 動作確認は手動実行とログ確認に依存
+**pytestベースの自動テストスイートは実装済みで、CIで自動実行されている。**
 
-### 推奨テスト戦略
+- **Pythonテスト**: `tests/` 配下に20テストモジュール・140テストが存在する（unittestで記述し、pytestで収集・実行する）
+- **CI**: `.github/workflows/tests.yml` が push / pull_request のたびに Python 3.11 / 3.12 / 3.13 のマトリクスで実行する（140件中3件は既知の理由で deselect。後述）
+- **回帰ガード**: ゴールデン回帰ハーネス `tests/test_golden_regression.py` が、説明のつかない REGRESSION 行を1件でも検出したらCIを失敗させる
+- **既知のギャップ**: `web/tests/` の node:test スイート（`node --test web/tests/`）は存在するが**CIに接続されていない**。Webビューア（`web/`）を変更したときは手動で実行すること
+- **既知の除外**: `tests/test_stock_exchange_mapping.py` の3テストがCIで deselect されている（後述）
 
-#### 単体テスト
-- lib/モジュールの個別機能をテスト
-- テストフレームワーク: pytest推奨
-- モック: unittest.mockを使用
+補助的に、実APIキーを使った手動スモークテストの手順を「Manual Smoke Testing」節に残している。これは自動スイートの代替ではなく、EDINET API / Yahoo への実接続を確認するための手順である。
 
-#### 統合テスト
-- EDINET APIとの連携テスト
-- XBRLパース処理の確認
-- エンドツーエンドのデータフロー検証
+## テストの実行方法
 
-#### E2Eテスト
-- 実際のAPIを使用した全体フローテスト
-- 日次実行スクリプトの動作確認
-- データ統合処理の検証
+### Pythonスイート
+```bash
+# 全件実行（uv 経由。推奨）
+uv run python -m pytest tests/ -v
 
-### テストの命名規則
+# 全件実行（venv / 素のpython）
+python -m pytest tests/ -v
+
+# 特定モジュールのみ
+python -m pytest tests/test_golden_regression.py -v
+
+# カバレッジ付き
+uv run python -m pytest tests/ -v --cov=lib --cov-report=term-missing
+```
+
+### CIと同じ条件で実行する
+CIは既知の失敗3件を deselect している。同じ条件を手元で再現するには:
+```bash
+python -m pytest tests/ -v \
+  --deselect tests/test_stock_exchange_mapping.py::TestStockExchangeMapping::test_fukuoka_stock_exchange \
+  --deselect tests/test_stock_exchange_mapping.py::TestStockExchangeMapping::test_nagoya_stock_exchange \
+  --deselect tests/test_stock_exchange_mapping.py::TestStockExchangeMapping::test_sapporo_stock_exchange
+```
+
+### Webビューアのスイート（CI未接続）
+```bash
+node --test web/tests/
+```
+新しい `*.test.js` を追加したときは `web/tests/index.js` に `require` を追記すること（Nodeの `--test` はディレクトリを再帰探索しないため、index経由で登録する）。
+
+## テストの追加方法
+
+### 命名規則
 ```python
 # テストファイル名
 test_<module_name>.py
@@ -32,18 +55,30 @@ test_<module_name>.py
 def test_<function_name>_<scenario>():
     """何をテストするかを明確に記述"""
     pass
-
-# 例
-def test_fetch_document_list_success():
-    """正常なAPI応答でドキュメントリストを取得できることを確認"""
-    pass
-
-def test_fetch_document_list_api_error():
-    """APIエラー時に適切に処理されることを確認"""
-    pass
 ```
 
-### モックの使い方
+### 既存の書き方に合わせる
+- テストは `unittest.TestCase` のサブクラスで書き、pytestで収集する（既存20モジュールがこの形式）
+- モックは `unittest.mock`（`patch` / `MagicMock`）を使う
+- 外部I/O（EDINET API、Yahoo）はテスト内で絶対に発生させない。必ずフィクスチャかモックで代替する
+
+### XBRL抽出のテストを追加する
+XBRL抽出ロジックを触るテストは、フィクスチャを直接パースするのではなく `tests/_xbrl_fixture_utils.py` のヘルパを使う:
+```python
+from _xbrl_fixture_utils import parse_fixture
+
+def test_something():
+    result = parse_fixture('consolidated_jgaap_2024.xbrl')
+    assert result['netSales'] == ...
+```
+`parse_fixture` はフィクスチャを EDINET の PublicDoc ZIP レイアウトに包んでパーサに渡し、決定的な合成市場データ（`SYNTHETIC_YAHOO`）を注入する。これによりPER/PBR/EVもオフラインで再現可能になる。
+
+### 新しいフィクスチャを追加する
+- `tests/fixtures/xbrl/` に置き、`tests/_xbrl_fixture_utils.py` の `FIXTURES` に登録する
+- 値はすべて**架空企業の明らかに偽の丸い数値**にする（entity `E00001` / secCode `9999`）。実企業の報告値は使わない
+- 登録したらゴールデンベースラインを再生成する（次節）
+
+### モックの例
 ```python
 from unittest.mock import patch, MagicMock
 
@@ -53,40 +88,84 @@ def test_api_call(mock_get):
     mock_response.status_code = 200
     mock_response.json.return_value = {"results": []}
     mock_get.return_value = mock_response
-    
-    # テスト実行
+
     result = fetch_document_list("dummy_key", "2025-06-28")
     assert result == []
 ```
 
-### カバレッジの目標値
+## ゴールデンベースラインの再生成
+
+`tests/golden/golden_baseline.json` は `tests/fixtures/xbrl/` の各フィクスチャから抽出した追跡フィールド（`netSales`, `operatingIncome`, `ordinaryIncome`, `netIncome`, `equity`, `cash`, `debt`, `eps`, `bps`, `per`, `pbr`, `outstandingShares`, `ev`, `marketCapitalization`, `stockPrice`）のスナップショットである。
+
+ハーネスは各フィールドについて `match` / `fix` / `REGRESSION` のいずれかの verdict を出す。`REGRESSION`（＝ベースラインと異なり、かつ許可リストにない）が1件でもあればCIが落ちる。
+
+**抽出ロジックを意図的に変更したときの手順**:
+
+1. `tests/test_golden_regression.py` の `EXPECTED_CHANGES` に `(フィクスチャ名, フィールド名) -> 新しい値` を追加する。これで該当行の verdict が `REGRESSION` から `fix` に変わり、レビュアーが差分の意図を読み取れる
+2. 変更がレビューで受け入れられたら、ベースラインを再生成する:
+   ```bash
+   REGEN_GOLDEN=1 python -m pytest tests/test_golden_regression.py
+   ```
+   この再生成は冪等である
+3. 再生成後、`EXPECTED_CHANGES` の該当エントリを削除する（ベースライン自体が新しい値になったため）
+
+**`golden_baseline.json` を手で編集してはならない。** 必ず `REGEN_GOLDEN=1` で再生成する。フィクスチャを追加した場合も同様に再生成が必要で、しなければ「golden baseline に存在しない」旨のアサーションで失敗する。
+
+## CIで deselect されている3テスト
+
+`.github/workflows/tests.yml` は以下の3テストを `--deselect` している:
+
+- `tests/test_stock_exchange_mapping.py::TestStockExchangeMapping::test_fukuoka_stock_exchange`
+- `tests/test_stock_exchange_mapping.py::TestStockExchangeMapping::test_nagoya_stock_exchange`
+- `tests/test_stock_exchange_mapping.py::TestStockExchangeMapping::test_sapporo_stock_exchange`
+
+**理由**: `config/stock_exchange_mapping.yml` の地方取引所マッピングデータが古く、これら3テストは既知の失敗状態にある。テストコード側の欠陥ではなくデータの陳腐化が原因であり、マッピングを更新するまで失敗し続ける。CI全体を赤にしたままにせず、既知失敗として明示的に除外している。
+
+**解消手順**: `.claude/rules/stock-exchange-mapping-update.md` の手順（または `update-stock-exchange-mapping` スキル）でマッピングを更新し、3テストが通ることを確認したうえで `.github/workflows/tests.yml` の `--deselect` 行を削除する。
+
+## テストデータの構成
+
+```
+tests/
+├── README.md                     # テスト実行方法のクイックリファレンス
+├── _xbrl_fixture_utils.py        # FIXTURES / GOLDEN_FIELDS / parse_fixture
+├── fixtures/
+│   ├── xbrl/                     # 合成XBRLフィクスチャ（すべて架空企業）
+│   │   ├── README.md
+│   │   ├── consolidated_jgaap_2024.xbrl      # JGAAP・2024-11-01タクソノミ
+│   │   ├── consolidated_jgaap_2025.xbrl      # JGAAP・2025-11-01タクソノミ
+│   │   ├── ifrs_2024.xbrl                    # IFRS（jpigp名前空間）
+│   │   ├── bank_2024.xbrl                    # 銀行業スキーマ
+│   │   ├── consolidated_vs_parent_2024.xbrl  # 連結≠個別のコンテキスト分岐
+│   │   └── tie_break_2024.xbrl               # 同点候補の決定的タイブレーク
+│   ├── yahoo_quote_sample.html   # Yahooクォートページ（正常系）
+│   ├── yahoo_quote_drift.html    # Yahooクォートページ（DOM変化）
+│   └── yahoo_quote_empty.html    # Yahooクォートページ（値なし）
+├── golden/
+│   └── golden_baseline.json      # ゴールデン回帰ベースライン（自動生成）
+└── test_*.py                     # 20テストモジュール
+```
+
+## カバレッジの目標値
 - 目標: コアロジックの80%以上
 - 重点領域:
   - XBRL解析ロジック
   - データ変換処理
   - エラーハンドリング
 
-### テストデータの管理方法
-```
-tests/
-├── fixtures/
-│   ├── sample_xbrl.xml      # サンプルXBRLデータ
-│   ├── api_responses.json   # APIレスポンスのモック
-│   └── expected_output.json # 期待される出力
-└── test_*.py               # テストファイル
-```
-
-### 将来の実装推奨事項
-1. pytestの導入
-2. CI/CDでのテスト自動実行
-3. テストカバレッジレポートの生成
+## 今後の改善候補
+1. `web/tests/` の node:test スイートをCIに接続する（現在は手動実行のみ）
+2. `config/stock_exchange_mapping.yml` を更新し、deselect されている3テストを復帰させる
+3. テストカバレッジレポートのCI出力・可視化
 4. パフォーマンステストの追加
 
-## Development Testing
+---
 
-### Running Tests
+## Manual Smoke Testing
 
-When you have an API key available, test the tools:
+自動スイートとは別に、実APIキーを使ってCLIツールのエンドツーエンド動作を確認する手順。自動テストの代替ではない。
+
+### Running the Tools
 
 #### Test fetch_edinet_financial_documents
 ```bash

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,7 +125,7 @@ else:
 - `tests/fixtures/xbrl/` に合成XBRLフィクスチャ（JGAAP 2024/2025、IFRS、銀行、連結≠個別、同点タイブレーク）を配置。すべて架空企業（entity `E00001` / secCode `9999`）の明示的に偽の数値で、`tests/_xbrl_fixture_utils.py` の `parse_fixture` から読み込む。
 - ゴールデン回帰ハーネス `tests/test_golden_regression.py` が抽出結果を `tests/golden/golden_baseline.json` と突き合わせ、`EXPECTED_CHANGES` 許可リスト外の REGRESSION 行が出たら失敗する（`REGEN_GOLDEN=1` で再生成、冪等）。
 - IFRS経路は `tests/test_ifrs_extraction.py` で検証（jpigp名前空間の解決、equity=`EquityIFRS`、net_sales=jpcrp IFRS売上サマリ、ordinaryIncome=null）。
-- Python 3.11/3.12/3.13 のCIマトリクスは `docs/ci/test-matrix.yml` に参照ワークフローとして提供。保護パス `.github/workflows/` への配置は人手で行う（自動エージェントは書き込まない）。
+- Python 3.11/3.12/3.13 のCIマトリクスは `.github/workflows/tests.yml` として適用済み。push / pull_request のたびに全件（20モジュール・140テスト）実行される。`tests/test_stock_exchange_mapping.py` の3テストは取引所マッピングデータが古く既知失敗のため `--deselect` されている（詳細は `.claude/rules/testing-guidelines.md`）。
 
 ### 市場データ取得アーキテクチャ（2026-06 更新, PR4 / issue #185）
 


### PR DESCRIPTION
## Summary

`.claude/rules/testing-guidelines.md` and `docs/architecture.md` both asserted that no test suite existed. A pytest suite (20 modules, 140 tests) and a three-version CI matrix have existed for some time; the docs never followed. Because all ten `.claude/rules/*.md` files load into every session, the stale file was actively telling every agent the suite did not exist.

`testing-guidelines.md` needed a structural rewrite rather than a line patch: patching individual lines would have left the "we do not have tests yet" narrative intact. It is now organized as current state -> how to run -> how to add a test -> golden baseline regeneration -> the three deselected tests and why.

## Changes

- Rewrote `.claude/rules/testing-guidelines.md`:
  - Current state now states the suite exists: 20 modules / 140 tests, `.github/workflows/tests.yml` on Python 3.11 / 3.12 / 3.13, push and pull_request
  - Added how-to-run (including the CI-equivalent invocation with the three `--deselect` flags) and how-to-add-a-test sections, the latter routing XBRL tests through `tests/_xbrl_fixture_utils.py`
  - Documented the `REGEN_GOLDEN=1` golden baseline regeneration procedure and the `EXPECTED_CHANGES` allowlist workflow, including that the baseline is never hand-edited
  - Documented the three deselected `tests/test_stock_exchange_mapping.py` tests, that stale mapping data (not a test defect) causes them, and how to remove the deselect. Fixing them is out of scope here
  - Replaced the fictional fixture tree (`sample_xbrl.xml`, `api_responses.json`, `expected_output.json`) with the real one: `tests/fixtures/xbrl/`, `tests/fixtures/yahoo_quote_*.html`, `tests/golden/golden_baseline.json`, `tests/_xbrl_fixture_utils.py`, `tests/README.md`
  - Documented the gap that `web/tests/` (`node --test web/tests/`) is not wired into CI
  - Kept the manual smoke-testing procedures, retitled to make clear they supplement rather than replace the automated suite
- `docs/architecture.md`: replaced the reference to the nonexistent `docs/ci/test-matrix.yml` and its manual-copy procedure with the applied `.github/workflows/tests.yml`

This PR edits no protected path. `.github/workflows/tests.yml` is referenced read-only. The `spec-synced-through` marker at `docs/architecture.md:2` is deliberately left untouched: this repairs a statement that was already wrong when written rather than syncing newer implementation, so bumping it would falsely claim coverage of the ~40 commits since.

## Verification

Commands run:

- `python -m pytest tests/ -q` with the three CI `--deselect` flags: **137 passed, 3 deselected** — confirms the documented 140 total and the deselect set
- `node --test web/tests/`: **9 pass, 0 fail** — confirms the documented command works
- `pytest --collect-only`: **140 tests collected**; `ls tests/test_*.py | wc -l`: **20** — confirms the documented counts
- Lint: skipped. `Makefile` defines only `install` / `install-legacy` / `clean` and there is no `package.json`, so the repo defines no lint command. `pyproject.toml` configures `ruff`/`black` but no runnable lint target is wired up
- Typecheck: skipped. Neither `Makefile` nor any project config defines a typecheck command
- Test: the repo defines no `test` target in `Makefile`, so the suite was invoked directly via pytest as above rather than through a project-defined command
- Code review (x-code-reviewer): **zero Critical, zero Warning**. Two Suggestions returned. Suggestion 1 (the summary bullet said CI runs "全件" while 3 tests are deselected) was applied. Suggestion 2 (a stale self-describing header comment inside `.github/workflows/tests.yml` still says the file lives under `docs/ci/`) was not applied: it touches a protected path and is out of scope for this issue

Acceptance criteria, graded by an independent grader running each named command:

- `git grep -q '明示的なテストスイートは未実装' -- .claude/rules/testing-guidelines.md` exits non-zero: **met** (exit 1)
- `git grep -q 'pytestの導入' -- .claude/rules/testing-guidelines.md` exits non-zero: **met** (exit 1)
- `git grep -q 'sample_xbrl.xml' -- .claude/rules/testing-guidelines.md` exits non-zero: **met** (exit 1)
- `git grep -q 'golden_baseline.json' -- .claude/rules/testing-guidelines.md` exits 0: **met**
- `git grep -qE '3\.11.*3\.12.*3\.13' -- .claude/rules/testing-guidelines.md` exits 0: **met**
- `git grep -q 'docs/ci' -- docs/architecture.md` exits non-zero: **met** (exit 1)
- `git grep -qF '.github/workflows/tests.yml' -- docs/architecture.md` exits 0 AND `git ls-files --error-unmatch .github/workflows/tests.yml` exits 0: **met** (both exit 0)
- `git diff main -- docs/architecture.md | grep -q 'spec-synced-through'` exits non-zero: **met** (exit 1)

All 8 criteria met on the first grading pass.

Closes #201