### PR TITLE
ci(workflows): drop false docs/ci staging note from tests.yml header

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,6 @@
-# Reference CI workflow for the test matrix + golden regression gate (issue #187).
+# CI: test matrix + golden regression gate (issue #187).
 #
-# This file lives under docs/ci/ because an automated agent must not write to
-# .github/workflows/ (protected path). A maintainer applies it by copying it to
-# .github/workflows/tests.yml in a separate, human-reviewed commit:
-#
-#     cp docs/ci/test-matrix.yml .github/workflows/tests.yml
-#     git add .github/workflows/tests.yml && git commit
-#
-# Once in place, every push / PR runs the suite on Python 3.11, 3.12, and 3.13.
+# Runs the pytest suite on Python 3.11, 3.12, and 3.13 for every push and PR.
 # The golden regression harness (tests/test_golden_regression.py) fails the job
 # on any unexplained REGRESSION row, so extraction drift breaks CI.
 #


### PR DESCRIPTION
## Summary

The header comment of `.github/workflows/tests.yml` claimed the file lived under `docs/ci/` and told the reader to copy it into place with `cp docs/ci/test-matrix.yml .github/workflows/tests.yml` - while being that file, at that path. `docs/ci/` does not exist, so the source of the `cp` is missing and its destination is the working CI config itself. Following the instruction yields `No such file` at best; an obedient agent truncates the workflow.

This removes the false staging note and keeps the two facts in the header that are genuinely useful. Comment-only: lines 17 onward are byte-identical.

## Changes

- Retitle line 1 to describe the applied state instead of a staging plan
- Delete the `docs/ci/` claim and the `cp` / `git add` instruction block
- Preserve the golden regression gate rationale
- Preserve the explanation of why the three `tests/test_stock_exchange_mapping.py` tests are deselected - the only such explanation anywhere in the repo

## Verification

Commands run:

- `.venv/bin/python -m pytest tests/ -q` with the three CI `--deselect` flags - 137 passed, 3 deselected
- Lint: no lint command defined (no `package.json`; `Makefile` defines only `install`, `install-legacy`, `clean`) - skipped
- Typecheck: no typecheck command defined - skipped
- Test: `Makefile` defines no `test` target; the suite was run directly with the CI invocation above
- `x-code-reviewer`: zero Critical, zero Warning (one out-of-scope suggestion noting line 1 still cites issue #187, which is accurate provenance)

Acceptance criteria:

- met - `git grep -q 'docs/ci' -- .github/workflows/tests.yml` exits 1 (non-zero): the dead path and its `cp` instruction are gone
- met - `git grep -q 'test_stock_exchange_mapping' -- .github/workflows/tests.yml` exits 0: the deselect rationale survived
- met - every added or removed line is a comment line (comment-line count check exits 0)
- met - no key or step line changed (`name:` / `on:` / `jobs:` / indented-line check exits 0)
- met - `.venv/bin/python -c "import yaml;yaml.safe_load(open('.github/workflows/tests.yml'))"` exits 0: the file still parses as YAML

Closes #202